### PR TITLE
i18n: internationalize all example/demo pages (Korean + English)

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -9,20 +9,14 @@ home:
   title: Let's Start
   subtitle: Together
   cta: Get Started
-  content: Lorem ipsum dolor sit amet, consectetur adipiscing
-    elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-    nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-    reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-    cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  content: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 signIn: Sign In
 signOut: Sign Out
-
 error:
   notFound:
     title: Oops!
     content: Sorry, an unexpected error has occurred.
     button: Go back to the home page
-
 example:
   accordion:
     - title: Is it accessible?
@@ -37,8 +31,7 @@ example:
   alertDialog:
     trigger: Show Dialog
     title: Are you absolutely sure?
-    content: This action cannot be undone. This will permanently delete your
-      account and remove your data from our servers.
+    content: This action cannot be undone. This will permanently delete your account and remove your data from our servers.
     confirm: Continue
     cancel: Cancel
   command:
@@ -58,3 +51,351 @@ example:
       calculator: Calculator
       profile: Profile
       billing: Billing
+    dialog:
+      press: Press
+      inputPlaceholder: Type a command or search...
+      noResults: No results found.
+      suggestions: Suggestions
+      calendar: Calendar
+      searchEmoji: Search Emoji
+      calculator: Calculator
+      settings: Settings
+      profile: Profile
+      billing: Billing
+    dropdownMenu:
+      createNewProject: Create a new project
+      actions: Actions
+      assignTo: Assign to...
+      setDueDate: Set due date...
+      applyLabel: Apply label
+      filterLabelPlaceholder: Filter label...
+      noLabelFound: No label found.
+      delete: Delete
+    popover:
+      status: Status
+      setStatus: Set status
+      changeStatusPlaceholder: Change status...
+      noResults: No results found.
+      backlog: Backlog
+      todo: Todo
+      inProgress: In Progress
+      done: Done
+      canceled: Canceled
+  input:
+    placeholder: Email
+    disabled:
+      placeholder: Email
+    file:
+      label: Picture
+    withButton:
+      placeholder: Email
+      button: Subscribe
+    withLabel:
+      label: Email
+      placeholder: Email
+    withText:
+      label: Email
+      placeholder: Email
+      description: Enter your email address.
+  textarea:
+    placeholder: Type your message here.
+    disabled:
+      placeholder: Type your message here.
+    withButton:
+      placeholder: Type your message here.
+      button: Send message
+    withLabel:
+      label: Your message
+      placeholder: Type your message here.
+    withText:
+      label: Your Message
+      placeholder: Type your message here.
+      description: Your message will be copied to the support team.
+  label:
+    label: Accept terms and conditions
+  select:
+    placeholder: Select a fruit
+    label: Fruits
+    apple: Apple
+    banana: Banana
+    blueberry: Blueberry
+    grapes: Grapes
+    pineapple: Pineapple
+  radioGroup:
+    default: Default
+    comfortable: Comfortable
+    compact: Compact
+  switch:
+    label: Airplane Mode
+  dialog:
+    editProfileButton: Edit Profile
+    title: Edit profile
+    description: Make changes to your profile here. Click save when you're done.
+    name: Name
+    username: Username
+    saveChanges: Save changes
+  sheet:
+    open: Open
+    title: Edit profile
+    description: Make changes to your profile here. Click save when you're done.
+    name: Name
+    username: Username
+    saveChanges: Save changes
+    position:
+      openSheet: Open {{position}} sheet
+      title: Edit profile
+      description: Make changes to your profile here. Click save when you're done.
+      name: Name
+      username: Username
+      saveChanges: Save changes
+    size:
+      openSheet: Open {{size}} sheet
+      title: Edit profile
+      description: Make changes to your profile here. Click save when you're done.
+      name: Name
+      username: Username
+      saveChanges: Save changes
+  popover:
+    openPopover: Open popover
+    dimensions: Dimensions
+    description: Set the dimensions for the layer.
+    width: Width
+    maxWidth: Max. width
+    height: Height
+    maxHeight: Max. height
+  hoverCard:
+    description: The React Framework – created and maintained by @vercel.
+    joined: Joined December 2021
+  tooltip:
+    add: Add
+    addToLibrary: Add to library
+  dropdownMenu:
+    open: Open
+    myAccount: My Account
+    profile: Profile
+    billing: Billing
+    settings: Settings
+    keyboardShortcuts: Keyboard shortcuts
+    team: Team
+    inviteUsers: Invite users
+    email: Email
+    message: Message
+    more: More...
+    newTeam: New Team
+    support: Support
+    api: API
+    logOut: Log out
+    checkboxes:
+      open: Open
+      appearance: Appearance
+      statusBar: Status Bar
+      activityBar: Activity Bar
+      panel: Panel
+    radioGroup:
+      open: Open
+      panelPosition: Panel Position
+      top: Top
+      bottom: Bottom
+      right: Right
+  contextMenu:
+    rightClickHere: Right click here
+    back: Back
+    forward: Forward
+    reload: Reload
+    moreTools: More Tools
+    savePageAs: Save Page As...
+    createShortcut: Create Shortcut...
+    nameWindow: Name Window...
+    developerTools: Developer Tools
+    showBookmarksBar: Show Bookmarks Bar
+    showFullUrls: Show Full URLs
+    people: People
+  menubar:
+    file: File
+    newTab: New Tab
+    newWindow: New Window
+    newIncognitoWindow: New Incognito Window
+    share: Share
+    emailLink: Email link
+    messages: Messages
+    notes: Notes
+    print: Print...
+    edit: Edit
+    undo: Undo
+    redo: Redo
+    find: Find
+    searchTheWeb: Search the web
+    findEllipsis: Find...
+    findNext: Find Next
+    findPrevious: Find Previous
+    cut: Cut
+    copy: Copy
+    paste: Paste
+    view: View
+    alwaysShowBookmarksBar: Always Show Bookmarks Bar
+    alwaysShowFullUrls: Always Show Full URLs
+    reload: Reload
+    forceReload: Force Reload
+    toggleFullscreen: Toggle Fullscreen
+    hideSidebar: Hide Sidebar
+    profiles: Profiles
+    editEllipsis: Edit...
+    addProfile: Add Profile...
+  navigationMenu:
+    gettingStarted: Getting started
+    components: Components
+    documentation: Documentation
+    heroDescription: Beautifully designed components built with Radix UI and Tailwind CSS.
+    introductionTitle: Introduction
+    introductionDescription: Re-usable components built using Radix UI and Tailwind CSS.
+    installationTitle: Installation
+    installationDescription: How to install dependencies and structure your app.
+    typographyTitle: Typography
+    typographyDescription: Styles for headings, paragraphs, lists...etc
+    alertDialogTitle: Alert Dialog
+    alertDialogDescription: A modal dialog that interrupts the user with important content and expects a response.
+    hoverCardTitle: Hover Card
+    hoverCardDescription: For sighted users to preview content available behind a link.
+    progressTitle: Progress
+    progressDescription: Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.
+    scrollAreaTitle: Scroll-area
+    scrollAreaDescription: Visually or semantically separates content.
+    tabsTitle: Tabs
+    tabsDescription: A set of layered sections of content—known as tab panels—that are displayed one at a time.
+    tooltipTitle: Tooltip
+    tooltipDescription: A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
+  tabs:
+    account: Account
+    password: Password
+    accountDescription: Make changes to your account here. Click save when you're done.
+    name: Name
+    username: Username
+    saveChanges: Save changes
+    passwordDescription: Change your password here. After saving, you'll be logged out.
+    currentPassword: Current password
+    newPassword: New password
+    savePassword: Save password
+  separator:
+    description: An open-source UI component library.
+    blog: Blog
+    docs: Docs
+    source: Source
+  scrollArea:
+    tags: Tags
+  toggle:
+    toggleItalic: Toggle italic
+    disabled:
+      toggleItalic: Toggle italic
+    lg:
+      toggleItalic: Toggle italic
+    outline:
+      toggleItalic: Toggle italic
+    sm:
+      toggleItalic: Toggle italic
+    withText:
+      toggleItalic: Toggle italic
+      italic: Italic
+  toast:
+    button: Add to calendar
+    title: 'Scheduled: Catch up '
+    description: Friday, February 10, 2023 at 5:57 PM
+    undo: Undo
+    undoAltText: Goto schedule to undo
+    simple:
+      button: Show Toast
+      description: Your message has been sent.
+    withTitle:
+      button: Show Toast
+      title: Uh oh! Something went wrong.
+      description: There was a problem with your request.
+    withAction:
+      button: Show Toast
+      title: Uh oh! Something went wrong.
+      description: There was a problem with your request.
+      action: Try again
+    destructive:
+      button: Show Toast
+      title: Uh oh! Something went wrong.
+      description: There was a problem with your request.
+      action: Try again
+  overview:
+    subtitle: Explore our collection of modern UI components and layouts.
+    feature1Title: Modern Sidebar
+    feature1Desc: Collapsible navigation with nested groups and icons.
+    feature2Title: Quick Search
+    feature2Desc: Instantly find components with real-time filtering.
+    feature3Title: Responsive Design
+    feature3Desc: Fully optimized for mobile, tablet, and desktop screens.
+    feature4Title: Clean Architecture
+    feature4Desc: Built with shadcn/ui and Radix UI primitives.
+    cardNote: Every component is designed to be accessible, performant, and easy to customize.
+    gettingStartedTitle: Getting Started
+    gettingStartedDesc: Select a component from the sidebar to view its interactive demo and documentation.
+  typography:
+    h1:
+      heading: 'Taxing Laughter: The Joke Tax Chronicles'
+    h2:
+      heading: The People of the Kingdom
+    h3:
+      heading: The Joke Tax
+    h4:
+      heading: People stopped telling jokes
+    blockquote:
+      quote: '"After all," he said, "everyone enjoys a good joke, so it''s only fair that they should pay for the privilege."'
+    large:
+      text: Are you sure absolutely sure?
+    lead:
+      lead: A modal dialog that interrupts the user with important content and expects a response.
+    muted:
+      text: Enter your email address.
+    p:
+      paragraph: The king, seeing how much happier his subjects were, realized the error of his ways and repealed the joke tax.
+    small:
+      text: Email address
+    list:
+      item1: '1st level of puns: 5 gold coins'
+      item2: '2nd level of jokes: 10 gold coins'
+      item3: '3rd level of one-liners : 20 gold coins'
+    table:
+      colTreasury: King's Treasury
+      colHappiness: People's happiness
+      row1Treasury: Empty
+      row1Happiness: Overflowing
+      row2Treasury: Modest
+      row2Happiness: Satisfied
+      row3Treasury: Full
+      row3Happiness: Ecstatic
+    demo:
+      title: The Joke Tax Chronicles
+      intro: 'Once upon a time, in a far-off land, there was a very lazy king who spent all day lounging on his throne. One day, his advisors came to him with a problem: the kingdom was running out of money.'
+      kingsPlanHeading: The King's Plan
+      kingsPlanBefore: The king thought long and hard, and finally came up with
+      kingsPlanLink: a brilliant plan
+      kingsPlanAfter: ': he would tax the jokes in the kingdom.'
+      quote: '"After all," he said, "everyone enjoys a good joke, so it''s only fair that they should pay for the privilege."'
+      jokeTaxHeading: The Joke Tax
+      jokeTaxParagraph: 'The king''s subjects were not amused. They grumbled and complained, but the king was firm:'
+      item1: '1st level of puns: 5 gold coins'
+      item2: '2nd level of jokes: 10 gold coins'
+      item3: '3rd level of one-liners : 20 gold coins'
+      jesterParagraph: 'As a result, people stopped telling jokes, and the kingdom fell into a gloom. But there was one person who refused to let the king''s foolishness get him down: a court jester named Jokester.'
+      revoltHeading: Jokester's Revolt
+      revoltParagraph: 'Jokester began sneaking into the castle in the middle of the night and leaving jokes all over the place: under the king''s pillow, in his soup, even in the royal toilet. The king was furious, but he couldn''t seem to stop Jokester.'
+      laughterParagraph: And then, one day, the people of the kingdom discovered that the jokes left by Jokester were so funny that they couldn't help but laugh. And once they started laughing, they couldn't stop.
+      rebellionHeading: The People's Rebellion
+      rebellionParagraph: The people of the kingdom, feeling uplifted by the laughter, started to tell jokes and puns again, and soon the entire kingdom was in on the joke.
+      colTreasury: King's Treasury
+      colHappiness: People's happiness
+      row1Treasury: Empty
+      row1Happiness: Overflowing
+      row2Treasury: Modest
+      row2Happiness: Satisfied
+      row3Treasury: Full
+      row3Happiness: Ecstatic
+      repealParagraph: The king, seeing how much happier his subjects were, realized the error of his ways and repealed the joke tax. Jokester was declared a hero, and the kingdom lived happily ever after.
+      moralParagraph: 'The moral of the story is: never underestimate the power of a good laugh and always be careful of bad ideas.'
+      labelH1: h1
+      labelH2: h2
+      labelH3: h3
+      labelH4: h4
+      labelInlineCode: Inline Code

--- a/public/locales/ko.yml
+++ b/public/locales/ko.yml
@@ -9,20 +9,14 @@ home:
   title: Let's Start
   subtitle: Together
   cta: 시작하기
-  content: Lorem ipsum dolor sit amet, consectetur adipiscing
-    elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-    nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
-    reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-    cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  content: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 signIn: 로그인
 signOut: 로그아웃
-
 error:
   notFound:
     title: 이런!
     content: 죄송합니다, 예기치 못한 오류가 발생했습니다.
     button: 홈페이지로 돌아가기
-
 example:
   accordion:
     - title: 접근성이 좋나요?
@@ -57,3 +51,351 @@ example:
       calculator: 계산기
       profile: 프로필
       billing: 결제
+    dialog:
+      press: 누르세요
+      inputPlaceholder: 명령어를 입력하거나 검색하세요...
+      noResults: 검색 결과가 없습니다.
+      suggestions: 추천
+      calendar: 캘린더
+      searchEmoji: 이모지 검색
+      calculator: 계산기
+      settings: 설정
+      profile: 프로필
+      billing: 결제
+    dropdownMenu:
+      createNewProject: 새 프로젝트 만들기
+      actions: 작업
+      assignTo: 담당자 지정...
+      setDueDate: 마감일 설정...
+      applyLabel: 라벨 적용
+      filterLabelPlaceholder: 라벨 필터...
+      noLabelFound: 라벨을 찾을 수 없습니다.
+      delete: 삭제
+    popover:
+      status: 상태
+      setStatus: 상태 설정
+      changeStatusPlaceholder: 상태 변경...
+      noResults: 검색 결과가 없습니다.
+      backlog: 백로그
+      todo: 할 일
+      inProgress: 진행 중
+      done: 완료
+      canceled: 취소됨
+  input:
+    placeholder: 이메일
+    disabled:
+      placeholder: 이메일
+    file:
+      label: 사진
+    withButton:
+      placeholder: 이메일
+      button: 구독
+    withLabel:
+      label: 이메일
+      placeholder: 이메일
+    withText:
+      label: 이메일
+      placeholder: 이메일
+      description: 이메일 주소를 입력하세요.
+  textarea:
+    placeholder: 메시지를 입력하세요.
+    disabled:
+      placeholder: 메시지를 입력하세요.
+    withButton:
+      placeholder: 메시지를 입력하세요.
+      button: 메시지 보내기
+    withLabel:
+      label: 메시지
+      placeholder: 메시지를 입력하세요.
+    withText:
+      label: 메시지
+      placeholder: 메시지를 입력하세요.
+      description: 메시지가 지원팀에 전달됩니다.
+  label:
+    label: 이용약관에 동의합니다
+  select:
+    placeholder: 과일 선택
+    label: 과일
+    apple: 사과
+    banana: 바나나
+    blueberry: 블루베리
+    grapes: 포도
+    pineapple: 파인애플
+  radioGroup:
+    default: 기본
+    comfortable: 넓게
+    compact: 좁게
+  switch:
+    label: 비행기 모드
+  dialog:
+    editProfileButton: 프로필 편집
+    title: 프로필 편집
+    description: 여기에서 프로필을 변경하세요. 완료되면 저장을 클릭하세요.
+    name: 이름
+    username: 사용자 이름
+    saveChanges: 변경사항 저장
+  sheet:
+    open: 열기
+    title: 프로필 편집
+    description: 여기에서 프로필을 변경하세요. 완료되면 저장을 클릭하세요.
+    name: 이름
+    username: 사용자 이름
+    saveChanges: 변경사항 저장
+    position:
+      openSheet: '{{position}} 시트 열기'
+      title: 프로필 편집
+      description: 여기에서 프로필을 변경하세요. 완료되면 저장을 클릭하세요.
+      name: 이름
+      username: 사용자 이름
+      saveChanges: 변경사항 저장
+    size:
+      openSheet: '{{size}} 시트 열기'
+      title: 프로필 편집
+      description: 여기에서 프로필을 변경하세요. 완료되면 저장을 클릭하세요.
+      name: 이름
+      username: 사용자 이름
+      saveChanges: 변경사항 저장
+  popover:
+    openPopover: 팝오버 열기
+    dimensions: 크기
+    description: 레이어의 크기를 설정하세요.
+    width: 너비
+    maxWidth: 최대 너비
+    height: 높이
+    maxHeight: 최대 높이
+  hoverCard:
+    description: React 프레임워크 – @vercel이 제작하고 관리합니다.
+    joined: 2021년 12월 가입
+  tooltip:
+    add: 추가
+    addToLibrary: 라이브러리에 추가
+  dropdownMenu:
+    open: 열기
+    myAccount: 내 계정
+    profile: 프로필
+    billing: 결제
+    settings: 설정
+    keyboardShortcuts: 키보드 단축키
+    team: 팀
+    inviteUsers: 사용자 초대
+    email: 이메일
+    message: 메시지
+    more: 더 보기...
+    newTeam: 새 팀
+    support: 지원
+    api: API
+    logOut: 로그아웃
+    checkboxes:
+      open: 열기
+      appearance: 화면 표시
+      statusBar: 상태 표시줄
+      activityBar: 활동 표시줄
+      panel: 패널
+    radioGroup:
+      open: 열기
+      panelPosition: 패널 위치
+      top: 위
+      bottom: 아래
+      right: 오른쪽
+  contextMenu:
+    rightClickHere: 여기를 우클릭하세요
+    back: 뒤로
+    forward: 앞으로
+    reload: 새로고침
+    moreTools: 도구 더 보기
+    savePageAs: 다른 이름으로 페이지 저장...
+    createShortcut: 바로 가기 만들기...
+    nameWindow: 창 이름 지정...
+    developerTools: 개발자 도구
+    showBookmarksBar: 북마크 바 표시
+    showFullUrls: 전체 URL 표시
+    people: 사람
+  menubar:
+    file: 파일
+    newTab: 새 탭
+    newWindow: 새 창
+    newIncognitoWindow: 새 시크릿 창
+    share: 공유
+    emailLink: 이메일 링크
+    messages: 메시지
+    notes: 메모
+    print: 인쇄...
+    edit: 편집
+    undo: 실행 취소
+    redo: 다시 실행
+    find: 찾기
+    searchTheWeb: 웹에서 검색
+    findEllipsis: 찾기...
+    findNext: 다음 찾기
+    findPrevious: 이전 찾기
+    cut: 잘라내기
+    copy: 복사
+    paste: 붙여넣기
+    view: 보기
+    alwaysShowBookmarksBar: 북마크 바 항상 표시
+    alwaysShowFullUrls: 전체 URL 항상 표시
+    reload: 새로고침
+    forceReload: 강제 새로고침
+    toggleFullscreen: 전체 화면 전환
+    hideSidebar: 사이드바 숨기기
+    profiles: 프로필
+    editEllipsis: 편집...
+    addProfile: 프로필 추가...
+  navigationMenu:
+    gettingStarted: 시작하기
+    components: 컴포넌트
+    documentation: 문서
+    heroDescription: Radix UI와 Tailwind CSS로 만든 아름답게 디자인된 컴포넌트입니다.
+    introductionTitle: 소개
+    introductionDescription: Radix UI와 Tailwind CSS로 만든 재사용 가능한 컴포넌트입니다.
+    installationTitle: 설치
+    installationDescription: 의존성을 설치하고 앱을 구성하는 방법입니다.
+    typographyTitle: 타이포그래피
+    typographyDescription: 제목, 문단, 목록 등의 스타일입니다.
+    alertDialogTitle: 알림 대화상자
+    alertDialogDescription: 중요한 내용으로 사용자를 중단시키고 응답을 요구하는 모달 대화상자입니다.
+    hoverCardTitle: 호버 카드
+    hoverCardDescription: 링크 뒤에 있는 콘텐츠를 미리 볼 수 있게 해줍니다.
+    progressTitle: 진행률
+    progressDescription: 작업의 완료 진행 상황을 보여주는 표시기로, 보통 진행 막대로 표시됩니다.
+    scrollAreaTitle: 스크롤 영역
+    scrollAreaDescription: 콘텐츠를 시각적 또는 의미적으로 구분합니다.
+    tabsTitle: 탭
+    tabsDescription: 한 번에 하나씩 표시되는 탭 패널이라고 불리는 계층형 콘텐츠 섹션 모음입니다.
+    tooltipTitle: 툴팁
+    tooltipDescription: 요소가 키보드 포커스를 받거나 마우스를 올렸을 때 관련 정보를 표시하는 팝업입니다.
+  tabs:
+    account: 계정
+    password: 비밀번호
+    accountDescription: 여기에서 계정을 변경하세요. 완료되면 저장을 클릭하세요.
+    name: 이름
+    username: 사용자 이름
+    saveChanges: 변경사항 저장
+    passwordDescription: 여기에서 비밀번호를 변경하세요. 저장 후에는 로그아웃됩니다.
+    currentPassword: 현재 비밀번호
+    newPassword: 새 비밀번호
+    savePassword: 비밀번호 저장
+  separator:
+    description: 오픈소스 UI 컴포넌트 라이브러리.
+    blog: 블로그
+    docs: 문서
+    source: 소스
+  scrollArea:
+    tags: 태그
+  toggle:
+    toggleItalic: 기울임꼴 전환
+    disabled:
+      toggleItalic: 기울임꼴 전환
+    lg:
+      toggleItalic: 기울임꼴 전환
+    outline:
+      toggleItalic: 기울임꼴 전환
+    sm:
+      toggleItalic: 기울임꼴 전환
+    withText:
+      toggleItalic: 기울임꼴 전환
+      italic: 기울임꼴
+  toast:
+    button: 캘린더에 추가
+    title: '예약됨: 따라잡기'
+    description: 2023년 2월 10일 금요일 오후 5:57
+    undo: 실행 취소
+    undoAltText: 일정으로 이동하여 실행 취소
+    simple:
+      button: 토스트 표시
+      description: 메시지가 전송되었습니다.
+    withTitle:
+      button: 토스트 표시
+      title: 이런! 문제가 발생했습니다.
+      description: 요청에 문제가 있었습니다.
+    withAction:
+      button: 토스트 표시
+      title: 이런! 문제가 발생했습니다.
+      description: 요청에 문제가 있었습니다.
+      action: 다시 시도
+    destructive:
+      button: 토스트 표시
+      title: 이런! 문제가 발생했습니다.
+      description: 요청에 문제가 있었습니다.
+      action: 다시 시도
+  overview:
+    subtitle: 최신 UI 컴포넌트와 레이아웃 모음을 살펴보세요.
+    feature1Title: 모던 사이드바
+    feature1Desc: 중첩 그룹과 아이콘이 있는 접이식 내비게이션.
+    feature2Title: 빠른 검색
+    feature2Desc: 실시간 필터링으로 컴포넌트를 즉시 찾기.
+    feature3Title: 반응형 디자인
+    feature3Desc: 모바일, 태블릿, 데스크톱 화면에 완벽하게 최적화.
+    feature4Title: 깔끔한 아키텍처
+    feature4Desc: shadcn/ui와 Radix UI 프리미티브로 제작.
+    cardNote: 모든 컴포넌트는 접근성, 성능, 손쉬운 커스터마이징을 고려해 설계되었습니다.
+    gettingStartedTitle: 시작하기
+    gettingStartedDesc: 사이드바에서 컴포넌트를 선택하여 인터랙티브 데모와 문서를 확인하세요.
+  typography:
+    h1:
+      heading: '웃음에 세금을: 농담세 연대기'
+    h2:
+      heading: 왕국의 백성들
+    h3:
+      heading: 농담세
+    h4:
+      heading: 사람들이 농담을 그만두다
+    blockquote:
+      quote: '"어차피" 그가 말했다, "누구나 재미있는 농담을 즐기니, 그 특권에 대가를 치르는 것이 공평하지 않겠나."'
+    large:
+      text: 정말로, 확실하신가요?
+    lead:
+      lead: 중요한 내용으로 사용자를 가로막고 응답을 요구하는 모달 대화 상자입니다.
+    muted:
+      text: 이메일 주소를 입력하세요.
+    p:
+      paragraph: 왕은 백성들이 훨씬 행복해진 모습을 보고 자신의 잘못을 깨달아 농담세를 폐지했다.
+    small:
+      text: 이메일 주소
+    list:
+      item1: '1단계 말장난: 금화 5닢'
+      item2: '2단계 농담: 금화 10닢'
+      item3: '3단계 한 줄 개그: 금화 20닢'
+    table:
+      colTreasury: 왕의 금고
+      colHappiness: 백성들의 행복
+      row1Treasury: 텅 빔
+      row1Happiness: 넘쳐흐름
+      row2Treasury: 적당함
+      row2Happiness: 만족함
+      row3Treasury: 가득 참
+      row3Happiness: 환희에 참
+    demo:
+      title: 농담세 연대기
+      intro: 옛날 옛적 머나먼 나라에, 하루 종일 왕좌에 늘어져 있는 아주 게으른 왕이 있었다. 어느 날, 신하들이 한 가지 문제를 들고 왕을 찾아왔다. 왕국의 돈이 바닥나고 있다는 것이었다.
+      kingsPlanHeading: 왕의 계획
+      kingsPlanBefore: 왕은 오래도록 고민한 끝에 마침내
+      kingsPlanLink: 기발한 계획
+      kingsPlanAfter: 을 떠올렸다. 바로 왕국의 농담에 세금을 매기는 것이었다.
+      quote: '"어차피" 그가 말했다, "누구나 재미있는 농담을 즐기니, 그 특권에 대가를 치르는 것이 공평하지 않겠나."'
+      jokeTaxHeading: 농담세
+      jokeTaxParagraph: 왕의 백성들은 전혀 즐겁지 않았다. 그들은 투덜대며 불평했지만, 왕은 단호했다.
+      item1: '1단계 말장난: 금화 5닢'
+      item2: '2단계 농담: 금화 10닢'
+      item3: '3단계 한 줄 개그: 금화 20닢'
+      jesterParagraph: 그 결과 사람들은 농담을 그만두었고, 왕국은 우울에 빠졌다. 하지만 왕의 어리석음에 굴하지 않은 단 한 사람이 있었으니, 바로 조커스터라는 이름의 궁정 광대였다.
+      revoltHeading: 조커스터의 반란
+      revoltParagraph: 조커스터는 한밤중에 성에 몰래 숨어들어 곳곳에 농담을 남기기 시작했다. 왕의 베개 밑에, 수프 속에, 심지어 왕실 변기 안에까지. 왕은 격노했지만, 도무지 조커스터를 막을 수 없었다.
+      laughterParagraph: 그러던 어느 날, 왕국의 백성들은 조커스터가 남긴 농담이 너무나 우스워 웃지 않을 수 없다는 것을 깨달았다. 그리고 한번 웃기 시작하자, 도저히 멈출 수가 없었다.
+      rebellionHeading: 백성들의 봉기
+      rebellionParagraph: 웃음으로 기운을 되찾은 왕국의 백성들은 다시 농담과 말장난을 하기 시작했고, 이내 온 왕국이 그 농담에 함께 빠져들었다.
+      colTreasury: 왕의 금고
+      colHappiness: 백성들의 행복
+      row1Treasury: 텅 빔
+      row1Happiness: 넘쳐흐름
+      row2Treasury: 적당함
+      row2Happiness: 만족함
+      row3Treasury: 가득 참
+      row3Happiness: 환희에 참
+      repealParagraph: 왕은 백성들이 훨씬 행복해진 모습을 보고 자신의 잘못을 깨달아 농담세를 폐지했다. 조커스터는 영웅으로 선포되었고, 왕국은 그 후로도 오래오래 행복하게 살았다.
+      moralParagraph: 이 이야기의 교훈은 이렇다. 한바탕 웃음의 힘을 결코 얕보지 말고, 나쁜 발상은 늘 경계하라.
+      labelH1: h1
+      labelH2: h2
+      labelH3: h3
+      labelH4: h4
+      labelInlineCode: 인라인 코드

--- a/src/pages/example/command/dialog.tsx
+++ b/src/pages/example/command/dialog.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {
   Calculator, Calendar, CreditCard, Settings, Smile, User,
 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import {
   CommandDialog,
   CommandEmpty,
@@ -15,6 +16,7 @@ import {
 } from '@/components/ui/command';
 
 export default function CommandDialogDemo() {
+  const { t } = useTranslation();
   const [open, setOpen] = React.useState(false);
 
   React.useEffect(() => {
@@ -31,44 +33,44 @@ export default function CommandDialogDemo() {
   return (
     <>
       <p className="text-sm text-muted-foreground">
-        Press{' '}
+        {t('example.command.dialog.press')}{' '}
         <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
           <span className="text-xs">⌘</span>J
         </kbd>
       </p>
       <CommandDialog open={open} onOpenChange={setOpen}>
-        <CommandInput placeholder="Type a command or search..." />
+        <CommandInput placeholder={t('example.command.dialog.inputPlaceholder')} />
         <CommandList>
-          <CommandEmpty>No results found.</CommandEmpty>
-          <CommandGroup heading="Suggestions">
+          <CommandEmpty>{t('example.command.dialog.noResults')}</CommandEmpty>
+          <CommandGroup heading={t('example.command.dialog.suggestions')}>
             <CommandItem>
               <Calendar className="mr-2 h-4 w-4" />
-              <span>Calendar</span>
+              <span>{t('example.command.dialog.calendar')}</span>
             </CommandItem>
             <CommandItem>
               <Smile className="mr-2 h-4 w-4" />
-              <span>Search Emoji</span>
+              <span>{t('example.command.dialog.searchEmoji')}</span>
             </CommandItem>
             <CommandItem>
               <Calculator className="mr-2 h-4 w-4" />
-              <span>Calculator</span>
+              <span>{t('example.command.dialog.calculator')}</span>
             </CommandItem>
           </CommandGroup>
           <CommandSeparator />
-          <CommandGroup heading="Settings">
+          <CommandGroup heading={t('example.command.dialog.settings')}>
             <CommandItem>
               <User className="mr-2 h-4 w-4" />
-              <span>Profile</span>
+              <span>{t('example.command.dialog.profile')}</span>
               <CommandShortcut>⌘P</CommandShortcut>
             </CommandItem>
             <CommandItem>
               <CreditCard className="mr-2 h-4 w-4" />
-              <span>Billing</span>
+              <span>{t('example.command.dialog.billing')}</span>
               <CommandShortcut>⌘B</CommandShortcut>
             </CommandItem>
             <CommandItem>
               <Settings className="mr-2 h-4 w-4" />
-              <span>Settings</span>
+              <span>{t('example.command.dialog.settings')}</span>
               <CommandShortcut>⌘S</CommandShortcut>
             </CommandItem>
           </CommandGroup>

--- a/src/pages/example/command/dropdown-menu.tsx
+++ b/src/pages/example/command/dropdown-menu.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {
   Calendar, MoreHorizontal, Tags, Trash, User,
 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList,
@@ -32,6 +33,7 @@ const labels = [
 ];
 
 export default function CommandDropdownMenu() {
+  const { t } = useTranslation();
   const [label, setLabel] = React.useState('feature');
   const [open, setOpen] = React.useState(false);
 
@@ -41,7 +43,7 @@ export default function CommandDropdownMenu() {
         <span className="mr-2 rounded-lg bg-primary px-2 py-1 text-xs text-primary-foreground">
           {label}
         </span>
-        <span className="text-muted-foreground">Create a new project</span>
+        <span className="text-muted-foreground">{t('example.command.dropdownMenu.createNewProject')}</span>
       </p>
       <DropdownMenu open={open} onOpenChange={setOpen}>
         <DropdownMenuTrigger asChild>
@@ -50,30 +52,30 @@ export default function CommandDropdownMenu() {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-[200px]">
-          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+          <DropdownMenuLabel>{t('example.command.dropdownMenu.actions')}</DropdownMenuLabel>
           <DropdownMenuGroup>
             <DropdownMenuItem>
               <User className="mr-2 h-4 w-4" />
-              Assign to...
+              {t('example.command.dropdownMenu.assignTo')}
             </DropdownMenuItem>
             <DropdownMenuItem>
               <Calendar className="mr-2 h-4 w-4" />
-              Set due date...
+              {t('example.command.dropdownMenu.setDueDate')}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <Tags className="mr-2 h-4 w-4" />
-                Apply label
+                {t('example.command.dropdownMenu.applyLabel')}
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="p-0">
                 <Command>
                   <CommandInput
-                    placeholder="Filter label..."
+                    placeholder={t('example.command.dropdownMenu.filterLabelPlaceholder')}
                     autoFocus
                   />
                   <CommandList>
-                    <CommandEmpty>No label found.</CommandEmpty>
+                    <CommandEmpty>{t('example.command.dropdownMenu.noLabelFound')}</CommandEmpty>
                     <CommandGroup>
                       {labels.map((label) => (
                         <CommandItem
@@ -94,7 +96,7 @@ export default function CommandDropdownMenu() {
             <DropdownMenuSeparator />
             <DropdownMenuItem className="text-red-600">
               <Trash className="mr-2 h-4 w-4" />
-              Delete
+              {t('example.command.dropdownMenu.delete')}
               <DropdownMenuShortcut>⌘⌫</DropdownMenuShortcut>
             </DropdownMenuItem>
           </DropdownMenuGroup>

--- a/src/pages/example/command/popover.tsx
+++ b/src/pages/example/command/popover.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 import {
   ArrowUpCircle, CheckCircle2, Circle, HelpCircle, LucideIcon, XCircle,
 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList,
@@ -16,35 +17,35 @@ type Status = {
   icon: LucideIcon
 }
 
-const statuses: Status[] = [
-  {
-    value: 'backlog',
-    label: 'Backlog',
-    icon: HelpCircle,
-  },
-  {
-    value: 'todo',
-    label: 'Todo',
-    icon: Circle,
-  },
-  {
-    value: 'in progress',
-    label: 'In Progress',
-    icon: ArrowUpCircle,
-  },
-  {
-    value: 'done',
-    label: 'Done',
-    icon: CheckCircle2,
-  },
-  {
-    value: 'canceled',
-    label: 'Canceled',
-    icon: XCircle,
-  },
-];
-
 export default function CommandPopover() {
+  const { t } = useTranslation();
+  const statuses: Status[] = [
+    {
+      value: 'backlog',
+      label: t('example.command.popover.backlog'),
+      icon: HelpCircle,
+    },
+    {
+      value: 'todo',
+      label: t('example.command.popover.todo'),
+      icon: Circle,
+    },
+    {
+      value: 'in progress',
+      label: t('example.command.popover.inProgress'),
+      icon: ArrowUpCircle,
+    },
+    {
+      value: 'done',
+      label: t('example.command.popover.done'),
+      icon: CheckCircle2,
+    },
+    {
+      value: 'canceled',
+      label: t('example.command.popover.canceled'),
+      icon: XCircle,
+    },
+  ];
   const [open, setOpen] = React.useState(false);
   const [selectedStatus, setSelectedStatus] = React.useState<Status | null>(
     null,
@@ -52,7 +53,7 @@ export default function CommandPopover() {
 
   return (
     <div className="flex items-center space-x-4">
-      <p className="text-sm text-muted-foreground">Status</p>
+      <p className="text-sm text-muted-foreground">{t('example.command.popover.status')}</p>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button
@@ -66,15 +67,15 @@ export default function CommandPopover() {
                 {selectedStatus.label}
               </>
             ) : (
-              <>+ Set status</>
+              <>+ {t('example.command.popover.setStatus')}</>
             )}
           </Button>
         </PopoverTrigger>
         <PopoverContent className="p-0" side="right" align="start">
           <Command>
-            <CommandInput placeholder="Change status..." />
+            <CommandInput placeholder={t('example.command.popover.changeStatusPlaceholder')} />
             <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
+              <CommandEmpty>{t('example.command.popover.noResults')}</CommandEmpty>
               <CommandGroup>
                 {statuses.map((status) => (
                   <CommandItem

--- a/src/pages/example/context-menu/demo.tsx
+++ b/src/pages/example/context-menu/demo.tsx
@@ -13,48 +13,50 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
+import { useTranslation } from 'react-i18next';
 
 export default function ContextMenuDemo() {
+  const { t } = useTranslation();
   return (
     <ContextMenu>
       <ContextMenuTrigger className="flex h-[150px] w-[300px] items-center justify-center rounded-md border border-dashed text-sm">
-        Right click here
+        {t('example.contextMenu.rightClickHere')}
       </ContextMenuTrigger>
       <ContextMenuContent className="w-64">
         <ContextMenuItem inset>
-          Back
+          {t('example.contextMenu.back')}
           <ContextMenuShortcut>⌘[</ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuItem inset disabled>
-          Forward
+          {t('example.contextMenu.forward')}
           <ContextMenuShortcut>⌘]</ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuItem inset>
-          Reload
+          {t('example.contextMenu.reload')}
           <ContextMenuShortcut>⌘R</ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuSub>
-          <ContextMenuSubTrigger inset>More Tools</ContextMenuSubTrigger>
+          <ContextMenuSubTrigger inset>{t('example.contextMenu.moreTools')}</ContextMenuSubTrigger>
           <ContextMenuSubContent className="w-48">
             <ContextMenuItem>
-              Save Page As...
+              {t('example.contextMenu.savePageAs')}
               <ContextMenuShortcut>⇧⌘S</ContextMenuShortcut>
             </ContextMenuItem>
-            <ContextMenuItem>Create Shortcut...</ContextMenuItem>
-            <ContextMenuItem>Name Window...</ContextMenuItem>
+            <ContextMenuItem>{t('example.contextMenu.createShortcut')}</ContextMenuItem>
+            <ContextMenuItem>{t('example.contextMenu.nameWindow')}</ContextMenuItem>
             <ContextMenuSeparator />
-            <ContextMenuItem>Developer Tools</ContextMenuItem>
+            <ContextMenuItem>{t('example.contextMenu.developerTools')}</ContextMenuItem>
           </ContextMenuSubContent>
         </ContextMenuSub>
         <ContextMenuSeparator />
         <ContextMenuCheckboxItem checked>
-          Show Bookmarks Bar
+          {t('example.contextMenu.showBookmarksBar')}
           <ContextMenuShortcut>⌘⇧B</ContextMenuShortcut>
         </ContextMenuCheckboxItem>
-        <ContextMenuCheckboxItem>Show Full URLs</ContextMenuCheckboxItem>
+        <ContextMenuCheckboxItem>{t('example.contextMenu.showFullUrls')}</ContextMenuCheckboxItem>
         <ContextMenuSeparator />
         <ContextMenuRadioGroup value="pedro">
-          <ContextMenuLabel inset>People</ContextMenuLabel>
+          <ContextMenuLabel inset>{t('example.contextMenu.people')}</ContextMenuLabel>
           <ContextMenuSeparator />
           <ContextMenuRadioItem value="pedro">
             Pedro Duarte

--- a/src/pages/example/dialog/demo.tsx
+++ b/src/pages/example/dialog/demo.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -13,36 +14,37 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 export default function DialogDemo() {
+  const { t } = useTranslation();
   const [name, setName] = useState('Pedro Duarte');
   const [userName, setUserName] = useState('@peduarte');
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline">Edit Profile</Button>
+        <Button variant="outline">{t('example.dialog.editProfileButton')}</Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
-          <DialogTitle>Edit profile</DialogTitle>
+          <DialogTitle>{t('example.dialog.title')}</DialogTitle>
           <DialogDescription>
-            Make changes to your profile here. Click save when you're done.
+            {t('example.dialog.description')}
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="name" className="text-right">
-              Name
+              {t('example.dialog.name')}
             </Label>
             <Input id="name" value={name} className="col-span-3" onChange={(e) => setName(e.target.value)} />
           </div>
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="username" className="text-right">
-              Username
+              {t('example.dialog.username')}
             </Label>
             <Input id="username" value={userName} onChange={(e) => setUserName(e.target.value)} className="col-span-3" />
           </div>
         </div>
         <DialogFooter>
-          <Button type="submit">Save changes</Button>
+          <Button type="submit">{t('example.dialog.saveChanges')}</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/pages/example/dropdown-menu/checkboxes.tsx
+++ b/src/pages/example/dropdown-menu/checkboxes.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DropdownMenuCheckboxItemProps } from '@radix-ui/react-dropdown-menu';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -14,6 +15,7 @@ import {
 type Checked = DropdownMenuCheckboxItemProps['checked']
 
 export default function DropdownMenuCheckboxes() {
+  const { t } = useTranslation();
   const [showStatusBar, setShowStatusBar] = React.useState<Checked>(true);
   const [showActivityBar, setShowActivityBar] = React.useState<Checked>(false);
   const [showPanel, setShowPanel] = React.useState<Checked>(false);
@@ -21,29 +23,29 @@ export default function DropdownMenuCheckboxes() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline">Open</Button>
+        <Button variant="outline">{t('example.dropdownMenu.checkboxes.open')}</Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56">
-        <DropdownMenuLabel>Appearance</DropdownMenuLabel>
+        <DropdownMenuLabel>{t('example.dropdownMenu.checkboxes.appearance')}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuCheckboxItem
           checked={showStatusBar}
           onCheckedChange={setShowStatusBar}
         >
-          Status Bar
+          {t('example.dropdownMenu.checkboxes.statusBar')}
         </DropdownMenuCheckboxItem>
         <DropdownMenuCheckboxItem
           checked={showActivityBar}
           onCheckedChange={setShowActivityBar}
           disabled
         >
-          Activity Bar
+          {t('example.dropdownMenu.checkboxes.activityBar')}
         </DropdownMenuCheckboxItem>
         <DropdownMenuCheckboxItem
           checked={showPanel}
           onCheckedChange={setShowPanel}
         >
-          Panel
+          {t('example.dropdownMenu.checkboxes.panel')}
         </DropdownMenuCheckboxItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/pages/example/dropdown-menu/index.tsx
+++ b/src/pages/example/dropdown-menu/index.tsx
@@ -12,6 +12,7 @@ import {
   UserPlus,
   Users,
 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -28,34 +29,35 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
-export default function index() {
+export default function DropdownMenuDemo() {
+  const { t } = useTranslation();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline">Open</Button>
+        <Button variant="outline">{t('example.dropdownMenu.open')}</Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56">
-        <DropdownMenuLabel>My Account</DropdownMenuLabel>
+        <DropdownMenuLabel>{t('example.dropdownMenu.myAccount')}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
           <DropdownMenuItem>
             <User className="mr-2 h-4 w-4" />
-            <span>Profile</span>
+            <span>{t('example.dropdownMenu.profile')}</span>
             <DropdownMenuShortcut>⇧⌘P</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuItem>
             <CreditCard className="mr-2 h-4 w-4" />
-            <span>Billing</span>
+            <span>{t('example.dropdownMenu.billing')}</span>
             <DropdownMenuShortcut>⌘B</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuItem>
             <Settings className="mr-2 h-4 w-4" />
-            <span>Settings</span>
+            <span>{t('example.dropdownMenu.settings')}</span>
             <DropdownMenuShortcut>⌘S</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuItem>
             <Keyboard className="mr-2 h-4 w-4" />
-            <span>Keyboard shortcuts</span>
+            <span>{t('example.dropdownMenu.keyboardShortcuts')}</span>
             <DropdownMenuShortcut>⌘K</DropdownMenuShortcut>
           </DropdownMenuItem>
         </DropdownMenuGroup>
@@ -63,50 +65,50 @@ export default function index() {
         <DropdownMenuGroup>
           <DropdownMenuItem>
             <Users className="mr-2 h-4 w-4" />
-            <span>Team</span>
+            <span>{t('example.dropdownMenu.team')}</span>
           </DropdownMenuItem>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
               <UserPlus className="mr-2 h-4 w-4" />
-              <span>Invite users</span>
+              <span>{t('example.dropdownMenu.inviteUsers')}</span>
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
               <DropdownMenuSubContent>
                 <DropdownMenuItem>
                   <Mail className="mr-2 h-4 w-4" />
-                  <span>Email</span>
+                  <span>{t('example.dropdownMenu.email')}</span>
                 </DropdownMenuItem>
                 <DropdownMenuItem>
                   <MessageSquare className="mr-2 h-4 w-4" />
-                  <span>Message</span>
+                  <span>{t('example.dropdownMenu.message')}</span>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem>
                   <PlusCircle className="mr-2 h-4 w-4" />
-                  <span>More...</span>
+                  <span>{t('example.dropdownMenu.more')}</span>
                 </DropdownMenuItem>
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
           </DropdownMenuSub>
           <DropdownMenuItem>
             <Plus className="mr-2 h-4 w-4" />
-            <span>New Team</span>
+            <span>{t('example.dropdownMenu.newTeam')}</span>
             <DropdownMenuShortcut>⌘+T</DropdownMenuShortcut>
           </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuItem>
           <LifeBuoy className="mr-2 h-4 w-4" />
-          <span>Support</span>
+          <span>{t('example.dropdownMenu.support')}</span>
         </DropdownMenuItem>
         <DropdownMenuItem disabled>
           <Cloud className="mr-2 h-4 w-4" />
-          <span>API</span>
+          <span>{t('example.dropdownMenu.api')}</span>
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem>
           <LogOut className="mr-2 h-4 w-4" />
-          <span>Log out</span>
+          <span>{t('example.dropdownMenu.logOut')}</span>
           <DropdownMenuShortcut>⇧⌘Q</DropdownMenuShortcut>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/pages/example/dropdown-menu/radio-group.tsx
+++ b/src/pages/example/dropdown-menu/radio-group.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -12,20 +13,21 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 export default function DropdownMenuRadioGroupDemo() {
+  const { t } = useTranslation();
   const [position, setPosition] = React.useState('bottom');
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline">Open</Button>
+        <Button variant="outline">{t('example.dropdownMenu.radioGroup.open')}</Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56">
-        <DropdownMenuLabel>Panel Position</DropdownMenuLabel>
+        <DropdownMenuLabel>{t('example.dropdownMenu.radioGroup.panelPosition')}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuRadioGroup value={position} onValueChange={setPosition}>
-          <DropdownMenuRadioItem value="top">Top</DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="bottom">Bottom</DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="right">Right</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="top">{t('example.dropdownMenu.radioGroup.top')}</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="bottom">{t('example.dropdownMenu.radioGroup.bottom')}</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="right">{t('example.dropdownMenu.radioGroup.right')}</DropdownMenuRadioItem>
         </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/pages/example/hover-card/demo.tsx
+++ b/src/pages/example/hover-card/demo.tsx
@@ -1,9 +1,11 @@
 import { CalendarDays } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 
 export default function HoverCardDemo() {
+  const { t } = useTranslation();
   return (
     <HoverCard>
       <HoverCardTrigger asChild>
@@ -18,12 +20,12 @@ export default function HoverCardDemo() {
           <div className="space-y-1">
             <h4 className="text-sm font-semibold">@nextjs</h4>
             <p className="text-sm">
-              The React Framework – created and maintained by @vercel.
+              {t('example.hoverCard.description')}
             </p>
             <div className="flex items-center pt-2">
               <CalendarDays className="mr-2 h-4 w-4 opacity-70" />{' '}
               <span className="text-xs text-muted-foreground">
-                Joined December 2021
+                {t('example.hoverCard.joined')}
               </span>
             </div>
           </div>

--- a/src/pages/example/index.tsx
+++ b/src/pages/example/index.tsx
@@ -7,23 +7,23 @@ export default function Index() {
   
   const features = [
     {
-      title: 'Modern Sidebar',
-      description: 'Collapsible navigation with nested groups and icons.',
+      title: t('example.overview.feature1Title'),
+      description: t('example.overview.feature1Desc'),
       icon: Layout
     },
     {
-      title: 'Quick Search',
-      description: 'Instantly find components with real-time filtering.',
+      title: t('example.overview.feature2Title'),
+      description: t('example.overview.feature2Desc'),
       icon: Search
     },
     {
-      title: 'Responsive Design',
-      description: 'Fully optimized for mobile, tablet, and desktop screens.',
+      title: t('example.overview.feature3Title'),
+      description: t('example.overview.feature3Desc'),
       icon: Smartphone
     },
     {
-      title: 'Clean Architecture',
-      description: 'Built with shadcn/ui and Radix UI primitives.',
+      title: t('example.overview.feature4Title'),
+      description: t('example.overview.feature4Desc'),
       icon: Layers
     }
   ];
@@ -33,7 +33,7 @@ export default function Index() {
       <div className="space-y-2">
         <h1 className="text-3xl font-bold tracking-tight">{t('menu.example')}</h1>
         <p className="text-lg text-muted-foreground">
-          Explore our collection of modern UI components and layouts.
+          {t('example.overview.subtitle')}
         </p>
       </div>
       
@@ -51,7 +51,7 @@ export default function Index() {
             </CardHeader>
             <CardContent>
                <p className="text-sm text-muted-foreground">
-                 Every component is designed to be accessible, performant, and easy to customize.
+                 {t('example.overview.cardNote')}
                </p>
             </CardContent>
           </Card>
@@ -60,9 +60,9 @@ export default function Index() {
 
       <Card className="bg-primary text-primary-foreground">
         <CardHeader>
-          <CardTitle>Getting Started</CardTitle>
+          <CardTitle>{t('example.overview.gettingStartedTitle')}</CardTitle>
           <CardDescription className="text-primary-foreground/80">
-            Select a component from the sidebar to view its interactive demo and documentation.
+            {t('example.overview.gettingStartedDesc')}
           </CardDescription>
         </CardHeader>
       </Card>

--- a/src/pages/example/input/demo.tsx
+++ b/src/pages/example/input/demo.tsx
@@ -1,5 +1,7 @@
+import { useTranslation } from 'react-i18next';
 import { Input } from '@/components/ui/input';
 
 export default function InputDemo() {
-  return <Input type="email" placeholder="Email" />;
+  const { t } = useTranslation();
+  return <Input type="email" placeholder={t('example.input.placeholder')} />;
 }

--- a/src/pages/example/input/disabled.tsx
+++ b/src/pages/example/input/disabled.tsx
@@ -1,5 +1,7 @@
+import { useTranslation } from 'react-i18next';
 import { Input } from '@/components/ui/input';
 
 export default function InputDisabled() {
-  return <Input disabled type="email" placeholder="Email" />;
+  const { t } = useTranslation();
+  return <Input disabled type="email" placeholder={t('example.input.disabled.placeholder')} />;
 }

--- a/src/pages/example/input/file.tsx
+++ b/src/pages/example/input/file.tsx
@@ -1,10 +1,12 @@
+import { useTranslation } from 'react-i18next';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 export default function InputFile() {
+  const { t } = useTranslation();
   return (
     <div className="grid w-full max-w-sm items-center gap-1.5">
-      <Label htmlFor="picture">Picture</Label>
+      <Label htmlFor="picture">{t('example.input.file.label')}</Label>
       <Input id="picture" type="file" />
     </div>
   );

--- a/src/pages/example/input/with-button.tsx
+++ b/src/pages/example/input/with-button.tsx
@@ -1,11 +1,13 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
 export default function InputWithButton() {
+  const { t } = useTranslation();
   return (
     <div className="flex w-full max-w-sm items-center space-x-2">
-      <Input type="email" placeholder="Email" />
-      <Button type="submit">Subscribe</Button>
+      <Input type="email" placeholder={t('example.input.withButton.placeholder')} />
+      <Button type="submit">{t('example.input.withButton.button')}</Button>
     </div>
   );
 }

--- a/src/pages/example/input/with-label.tsx
+++ b/src/pages/example/input/with-label.tsx
@@ -1,11 +1,13 @@
+import { useTranslation } from 'react-i18next';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 export default function InputWithLabel() {
+  const { t } = useTranslation();
   return (
     <div className="grid w-full max-w-sm items-center gap-1.5">
-      <Label htmlFor="email">Email</Label>
-      <Input type="email" id="email" placeholder="Email" />
+      <Label htmlFor="email">{t('example.input.withLabel.label')}</Label>
+      <Input type="email" id="email" placeholder={t('example.input.withLabel.placeholder')} />
     </div>
   );
 }

--- a/src/pages/example/input/with-text.tsx
+++ b/src/pages/example/input/with-text.tsx
@@ -1,12 +1,14 @@
+import { useTranslation } from 'react-i18next';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 export default function InputWithText() {
+  const { t } = useTranslation();
   return (
     <div className="grid w-full max-w-sm items-center gap-1.5">
-      <Label htmlFor="email-2">Email</Label>
-      <Input type="email" id="email-2" placeholder="Email" />
-      <p className="text-sm text-muted-foreground">Enter your email address.</p>
+      <Label htmlFor="email-2">{t('example.input.withText.label')}</Label>
+      <Input type="email" id="email-2" placeholder={t('example.input.withText.placeholder')} />
+      <p className="text-sm text-muted-foreground">{t('example.input.withText.description')}</p>
     </div>
   );
 }

--- a/src/pages/example/label/demo.tsx
+++ b/src/pages/example/label/demo.tsx
@@ -1,12 +1,14 @@
+import { useTranslation } from 'react-i18next';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 
 export default function LabelDemo() {
+  const { t } = useTranslation();
   return (
     <div>
       <div className="flex items-center space-x-2">
         <Checkbox id="terms" />
-        <Label htmlFor="terms">Accept terms and conditions</Label>
+        <Label htmlFor="terms">{t('example.label.label')}</Label>
       </div>
     </div>
   );

--- a/src/pages/example/menubar/demo.tsx
+++ b/src/pages/example/menubar/demo.tsx
@@ -13,83 +13,85 @@ import {
   MenubarSubTrigger,
   MenubarTrigger,
 } from '@/components/ui/menubar';
+import { useTranslation } from 'react-i18next';
 
 export default function MenubarDemo() {
+  const { t } = useTranslation();
   return (
     <Menubar>
       <MenubarMenu>
-        <MenubarTrigger>File</MenubarTrigger>
+        <MenubarTrigger>{t('example.menubar.file')}</MenubarTrigger>
         <MenubarContent>
           <MenubarItem>
-            New Tab <MenubarShortcut>⌘T</MenubarShortcut>
+            {t('example.menubar.newTab')} <MenubarShortcut>⌘T</MenubarShortcut>
           </MenubarItem>
           <MenubarItem>
-            New Window <MenubarShortcut>⌘N</MenubarShortcut>
+            {t('example.menubar.newWindow')} <MenubarShortcut>⌘N</MenubarShortcut>
           </MenubarItem>
-          <MenubarItem disabled>New Incognito Window</MenubarItem>
+          <MenubarItem disabled>{t('example.menubar.newIncognitoWindow')}</MenubarItem>
           <MenubarSeparator />
           <MenubarSub>
-            <MenubarSubTrigger>Share</MenubarSubTrigger>
+            <MenubarSubTrigger>{t('example.menubar.share')}</MenubarSubTrigger>
             <MenubarSubContent>
-              <MenubarItem>Email link</MenubarItem>
-              <MenubarItem>Messages</MenubarItem>
-              <MenubarItem>Notes</MenubarItem>
+              <MenubarItem>{t('example.menubar.emailLink')}</MenubarItem>
+              <MenubarItem>{t('example.menubar.messages')}</MenubarItem>
+              <MenubarItem>{t('example.menubar.notes')}</MenubarItem>
             </MenubarSubContent>
           </MenubarSub>
           <MenubarSeparator />
           <MenubarItem>
-            Print... <MenubarShortcut>⌘P</MenubarShortcut>
+            {t('example.menubar.print')} <MenubarShortcut>⌘P</MenubarShortcut>
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
       <MenubarMenu>
-        <MenubarTrigger>Edit</MenubarTrigger>
+        <MenubarTrigger>{t('example.menubar.edit')}</MenubarTrigger>
         <MenubarContent>
           <MenubarItem>
-            Undo <MenubarShortcut>⌘Z</MenubarShortcut>
+            {t('example.menubar.undo')} <MenubarShortcut>⌘Z</MenubarShortcut>
           </MenubarItem>
           <MenubarItem>
-            Redo <MenubarShortcut>⇧⌘Z</MenubarShortcut>
+            {t('example.menubar.redo')} <MenubarShortcut>⇧⌘Z</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
           <MenubarSub>
-            <MenubarSubTrigger>Find</MenubarSubTrigger>
+            <MenubarSubTrigger>{t('example.menubar.find')}</MenubarSubTrigger>
             <MenubarSubContent>
-              <MenubarItem>Search the web</MenubarItem>
+              <MenubarItem>{t('example.menubar.searchTheWeb')}</MenubarItem>
               <MenubarSeparator />
-              <MenubarItem>Find...</MenubarItem>
-              <MenubarItem>Find Next</MenubarItem>
-              <MenubarItem>Find Previous</MenubarItem>
+              <MenubarItem>{t('example.menubar.findEllipsis')}</MenubarItem>
+              <MenubarItem>{t('example.menubar.findNext')}</MenubarItem>
+              <MenubarItem>{t('example.menubar.findPrevious')}</MenubarItem>
             </MenubarSubContent>
           </MenubarSub>
           <MenubarSeparator />
-          <MenubarItem>Cut</MenubarItem>
-          <MenubarItem>Copy</MenubarItem>
-          <MenubarItem>Paste</MenubarItem>
+          <MenubarItem>{t('example.menubar.cut')}</MenubarItem>
+          <MenubarItem>{t('example.menubar.copy')}</MenubarItem>
+          <MenubarItem>{t('example.menubar.paste')}</MenubarItem>
         </MenubarContent>
       </MenubarMenu>
       <MenubarMenu>
-        <MenubarTrigger>View</MenubarTrigger>
+        <MenubarTrigger>{t('example.menubar.view')}</MenubarTrigger>
         <MenubarContent>
-          <MenubarCheckboxItem>Always Show Bookmarks Bar</MenubarCheckboxItem>
+          <MenubarCheckboxItem>{t('example.menubar.alwaysShowBookmarksBar')}</MenubarCheckboxItem>
           <MenubarCheckboxItem checked>
-            Always Show Full URLs
+            {t('example.menubar.alwaysShowFullUrls')}
           </MenubarCheckboxItem>
           <MenubarSeparator />
           <MenubarItem inset>
-            Reload <MenubarShortcut>⌘R</MenubarShortcut>
+            {t('example.menubar.reload')} <MenubarShortcut>⌘R</MenubarShortcut>
           </MenubarItem>
           <MenubarItem disabled inset>
-            Force Reload <MenubarShortcut>⇧⌘R</MenubarShortcut>
+            {t('example.menubar.forceReload')} <MenubarShortcut>⇧⌘R</MenubarShortcut>
           </MenubarItem>
           <MenubarSeparator />
-          <MenubarItem inset>Toggle Fullscreen</MenubarItem>
+          <MenubarItem inset>{t('example.menubar.toggleFullscreen')}</MenubarItem>
           <MenubarSeparator />
-          <MenubarItem inset>Hide Sidebar</MenubarItem>
+          <MenubarItem inset>{t('example.menubar.hideSidebar')}</MenubarItem>
         </MenubarContent>
       </MenubarMenu>
       <MenubarMenu>
-        <MenubarTrigger>Profiles</MenubarTrigger>
+        <MenubarTrigger>{t('example.menubar.profiles')}</MenubarTrigger>
         <MenubarContent>
           <MenubarRadioGroup value="benoit">
             <MenubarRadioItem value="andy">Andy</MenubarRadioItem>
@@ -97,9 +99,9 @@ export default function MenubarDemo() {
             <MenubarRadioItem value="Luis">Luis</MenubarRadioItem>
           </MenubarRadioGroup>
           <MenubarSeparator />
-          <MenubarItem inset>Edit...</MenubarItem>
+          <MenubarItem inset>{t('example.menubar.editEllipsis')}</MenubarItem>
           <MenubarSeparator />
-          <MenubarItem inset>Add Profile...</MenubarItem>
+          <MenubarItem inset>{t('example.menubar.addProfile')}</MenubarItem>
         </MenubarContent>
       </MenubarMenu>
     </Menubar>

--- a/src/pages/example/navigation-menu/demo.tsx
+++ b/src/pages/example/navigation-menu/demo.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import {
   NavigationMenu,
@@ -12,50 +13,45 @@ import {
   navigationMenuTriggerStyle,
 } from '@/components/ui/navigation-menu';
 
-const components: { title: string; href: string; description: string }[] = [
-  {
-    title: 'Alert Dialog',
-    href: '/docs/primitives/alert-dialog',
-    description:
-      'A modal dialog that interrupts the user with important content and expects a response.',
-  },
-  {
-    title: 'Hover Card',
-    href: '/docs/primitives/hover-card',
-    description:
-      'For sighted users to preview content available behind a link.',
-  },
-  {
-    title: 'Progress',
-    href: '/docs/primitives/progress',
-    description:
-      'Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.',
-  },
-  {
-    title: 'Scroll-area',
-    href: '/docs/primitives/scroll-area',
-    description: 'Visually or semantically separates content.',
-  },
-  {
-    title: 'Tabs',
-    href: '/docs/primitives/tabs',
-    description:
-      'A set of layered sections of content—known as tab panels—that are displayed one at a time.',
-  },
-  {
-    title: 'Tooltip',
-    href: '/docs/primitives/tooltip',
-    description:
-      'A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.',
-  },
-];
-
 export default function NavigationMenuDemo() {
+  const { t } = useTranslation();
+  const components: { title: string; href: string; description: string }[] = [
+    {
+      title: t('example.navigationMenu.alertDialogTitle'),
+      href: '/docs/primitives/alert-dialog',
+      description: t('example.navigationMenu.alertDialogDescription'),
+    },
+    {
+      title: t('example.navigationMenu.hoverCardTitle'),
+      href: '/docs/primitives/hover-card',
+      description: t('example.navigationMenu.hoverCardDescription'),
+    },
+    {
+      title: t('example.navigationMenu.progressTitle'),
+      href: '/docs/primitives/progress',
+      description: t('example.navigationMenu.progressDescription'),
+    },
+    {
+      title: t('example.navigationMenu.scrollAreaTitle'),
+      href: '/docs/primitives/scroll-area',
+      description: t('example.navigationMenu.scrollAreaDescription'),
+    },
+    {
+      title: t('example.navigationMenu.tabsTitle'),
+      href: '/docs/primitives/tabs',
+      description: t('example.navigationMenu.tabsDescription'),
+    },
+    {
+      title: t('example.navigationMenu.tooltipTitle'),
+      href: '/docs/primitives/tooltip',
+      description: t('example.navigationMenu.tooltipDescription'),
+    },
+  ];
   return (
     <NavigationMenu>
       <NavigationMenuList>
         <NavigationMenuItem>
-          <NavigationMenuTrigger>Getting started</NavigationMenuTrigger>
+          <NavigationMenuTrigger>{t('example.navigationMenu.gettingStarted')}</NavigationMenuTrigger>
           <NavigationMenuContent>
             <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
               <li className="row-span-3">
@@ -68,26 +64,25 @@ export default function NavigationMenuDemo() {
                       shadcn/ui
                     </div>
                     <p className="text-sm leading-tight text-muted-foreground">
-                      Beautifully designed components built with Radix UI and
-                      Tailwind CSS.
+                      {t('example.navigationMenu.heroDescription')}
                     </p>
                   </a>
                 </NavigationMenuLink>
               </li>
-              <ListItem href="/docs" title="Introduction">
-                Re-usable components built using Radix UI and Tailwind CSS.
+              <ListItem href="/docs" title={t('example.navigationMenu.introductionTitle')}>
+                {t('example.navigationMenu.introductionDescription')}
               </ListItem>
-              <ListItem href="/docs/installation" title="Installation">
-                How to install dependencies and structure your app.
+              <ListItem href="/docs/installation" title={t('example.navigationMenu.installationTitle')}>
+                {t('example.navigationMenu.installationDescription')}
               </ListItem>
-              <ListItem href="/docs/primitives/typography" title="Typography">
-                Styles for headings, paragraphs, lists...etc
+              <ListItem href="/docs/primitives/typography" title={t('example.navigationMenu.typographyTitle')}>
+                {t('example.navigationMenu.typographyDescription')}
               </ListItem>
             </ul>
           </NavigationMenuContent>
         </NavigationMenuItem>
         <NavigationMenuItem>
-          <NavigationMenuTrigger>Components</NavigationMenuTrigger>
+          <NavigationMenuTrigger>{t('example.navigationMenu.components')}</NavigationMenuTrigger>
           <NavigationMenuContent>
             <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px] ">
               {components.map((component) => (
@@ -104,7 +99,7 @@ export default function NavigationMenuDemo() {
         </NavigationMenuItem>
         <NavigationMenuItem>
           <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
-            <Link to="/docs">Documentation</Link>
+            <Link to="/docs">{t('example.navigationMenu.documentation')}</Link>
           </NavigationMenuLink>
         </NavigationMenuItem>
       </NavigationMenuList>

--- a/src/pages/example/popover/demo.tsx
+++ b/src/pages/example/popover/demo.tsx
@@ -1,29 +1,31 @@
 import { Settings } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 export default function PopoverDemo() {
+  const { t } = useTranslation();
   return (
     <Popover>
       <PopoverTrigger asChild>
         <Button variant="outline" className="w-10 rounded-full p-0">
           <Settings className="h-4 w-4" />
-          <span className="sr-only">Open popover</span>
+          <span className="sr-only">{t('example.popover.openPopover')}</span>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-80">
         <div className="grid gap-4">
           <div className="space-y-2">
-            <h4 className="font-medium leading-none">Dimensions</h4>
+            <h4 className="font-medium leading-none">{t('example.popover.dimensions')}</h4>
             <p className="text-sm text-muted-foreground">
-              Set the dimensions for the layer.
+              {t('example.popover.description')}
             </p>
           </div>
           <div className="grid gap-2">
             <div className="grid grid-cols-3 items-center gap-4">
-              <Label htmlFor="width">Width</Label>
+              <Label htmlFor="width">{t('example.popover.width')}</Label>
               <Input
                 id="width"
                 defaultValue="100%"
@@ -31,7 +33,7 @@ export default function PopoverDemo() {
               />
             </div>
             <div className="grid grid-cols-3 items-center gap-4">
-              <Label htmlFor="maxWidth">Max. width</Label>
+              <Label htmlFor="maxWidth">{t('example.popover.maxWidth')}</Label>
               <Input
                 id="maxWidth"
                 defaultValue="300px"
@@ -39,7 +41,7 @@ export default function PopoverDemo() {
               />
             </div>
             <div className="grid grid-cols-3 items-center gap-4">
-              <Label htmlFor="height">Height</Label>
+              <Label htmlFor="height">{t('example.popover.height')}</Label>
               <Input
                 id="height"
                 defaultValue="25px"
@@ -47,7 +49,7 @@ export default function PopoverDemo() {
               />
             </div>
             <div className="grid grid-cols-3 items-center gap-4">
-              <Label htmlFor="maxHeight">Max. height</Label>
+              <Label htmlFor="maxHeight">{t('example.popover.maxHeight')}</Label>
               <Input
                 id="maxHeight"
                 defaultValue="none"

--- a/src/pages/example/radio-group/demo.tsx
+++ b/src/pages/example/radio-group/demo.tsx
@@ -1,20 +1,22 @@
+import { useTranslation } from 'react-i18next';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 
 export default function RadioGroupDemo() {
+  const { t } = useTranslation();
   return (
     <RadioGroup defaultValue="comfortable">
       <div className="flex items-center space-x-2">
         <RadioGroupItem value="default" id="r1" />
-        <Label htmlFor="r1">Default</Label>
+        <Label htmlFor="r1">{t('example.radioGroup.default')}</Label>
       </div>
       <div className="flex items-center space-x-2">
         <RadioGroupItem value="comfortable" id="r2" />
-        <Label htmlFor="r2">Comfortable</Label>
+        <Label htmlFor="r2">{t('example.radioGroup.comfortable')}</Label>
       </div>
       <div className="flex items-center space-x-2">
         <RadioGroupItem value="compact" id="r3" />
-        <Label htmlFor="r3">Compact</Label>
+        <Label htmlFor="r3">{t('example.radioGroup.compact')}</Label>
       </div>
     </RadioGroup>
   );

--- a/src/pages/example/scroll-area/demo.tsx
+++ b/src/pages/example/scroll-area/demo.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 
@@ -6,10 +7,11 @@ const tags = Array.from({ length: 50 }).map(
 );
 
 export default function ScrollAreaDemo() {
+  const { t } = useTranslation();
   return (
     <ScrollArea className="h-72 w-48 rounded-md border">
       <div className="p-4">
-        <h4 className="mb-4 text-sm font-medium leading-none">Tags</h4>
+        <h4 className="mb-4 text-sm font-medium leading-none">{t('example.scrollArea.tags')}</h4>
         {tags.map((tag) => (
           <>
             <div className="text-sm" key={tag}>

--- a/src/pages/example/select/demo.tsx
+++ b/src/pages/example/select/demo.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import {
   Select,
   SelectContent,
@@ -9,19 +10,20 @@ import {
 } from '@/components/ui/select';
 
 export default function SelectDemo() {
+  const { t } = useTranslation();
   return (
     <Select>
       <SelectTrigger className="w-[180px]">
-        <SelectValue placeholder="Select a fruit" />
+        <SelectValue placeholder={t('example.select.placeholder')} />
       </SelectTrigger>
       <SelectContent>
         <SelectGroup>
-          <SelectLabel>Fruits</SelectLabel>
-          <SelectItem value="apple">Apple</SelectItem>
-          <SelectItem value="banana">Banana</SelectItem>
-          <SelectItem value="blueberry">Blueberry</SelectItem>
-          <SelectItem value="grapes">Grapes</SelectItem>
-          <SelectItem value="pineapple">Pineapple</SelectItem>
+          <SelectLabel>{t('example.select.label')}</SelectLabel>
+          <SelectItem value="apple">{t('example.select.apple')}</SelectItem>
+          <SelectItem value="banana">{t('example.select.banana')}</SelectItem>
+          <SelectItem value="blueberry">{t('example.select.blueberry')}</SelectItem>
+          <SelectItem value="grapes">{t('example.select.grapes')}</SelectItem>
+          <SelectItem value="pineapple">{t('example.select.pineapple')}</SelectItem>
         </SelectGroup>
       </SelectContent>
     </Select>

--- a/src/pages/example/separator/demo.tsx
+++ b/src/pages/example/separator/demo.tsx
@@ -1,21 +1,23 @@
+import { useTranslation } from 'react-i18next';
 import { Separator } from '@/components/ui/separator';
 
 export default function SeparatorDemo() {
+  const { t } = useTranslation();
   return (
     <div>
       <div className="space-y-1">
         <h4 className="text-sm font-medium leading-none">Radix Primitives</h4>
         <p className="text-sm text-muted-foreground">
-          An open-source UI component library.
+          {t('example.separator.description')}
         </p>
       </div>
       <Separator className="my-4" />
       <div className="flex h-5 items-center space-x-4 text-sm">
-        <div>Blog</div>
+        <div>{t('example.separator.blog')}</div>
         <Separator orientation="vertical" />
-        <div>Docs</div>
+        <div>{t('example.separator.docs')}</div>
         <Separator orientation="vertical" />
-        <div>Source</div>
+        <div>{t('example.separator.source')}</div>
       </div>
     </div>
   );

--- a/src/pages/example/sheet/demo.tsx
+++ b/src/pages/example/sheet/demo.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -12,34 +13,35 @@ import {
 } from '@/components/ui/sheet';
 
 export default function SheetDemo() {
+  const { t } = useTranslation();
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <Button variant="outline">Open</Button>
+        <Button variant="outline">{t('example.sheet.open')}</Button>
       </SheetTrigger>
       <SheetContent side="right" size="sm">
         <SheetHeader>
-          <SheetTitle>Edit profile</SheetTitle>
+          <SheetTitle>{t('example.sheet.title')}</SheetTitle>
           <SheetDescription>
-            Make changes to your profile here. Click save when you're done.
+            {t('example.sheet.description')}
           </SheetDescription>
         </SheetHeader>
         <div className="grid gap-4 py-4">
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="name" className="text-right">
-              Name
+              {t('example.sheet.name')}
             </Label>
             <Input id="name" value="Pedro Duarte" className="col-span-3" />
           </div>
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="username" className="text-right">
-              Username
+              {t('example.sheet.username')}
             </Label>
             <Input id="username" value="@peduarte" className="col-span-3" />
           </div>
         </div>
         <SheetFooter>
-          <Button type="submit">Save changes</Button>
+          <Button type="submit">{t('example.sheet.saveChanges')}</Button>
         </SheetFooter>
       </SheetContent>
     </Sheet>

--- a/src/pages/example/sheet/position.tsx
+++ b/src/pages/example/sheet/position.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -19,6 +20,7 @@ const SHEET_POSITIONS = ['top', 'right', 'bottom', 'left'] as const;
 type SheetPosition = (typeof SHEET_POSITIONS)[number]
 
 export default function SheetPosition() {
+  const { t } = useTranslation();
   const [position, setPosition] = useState<SheetPosition>('right');
   return (
     <div className="flex flex-col space-y-8">
@@ -40,31 +42,31 @@ export default function SheetPosition() {
       </RadioGroup>
       <Sheet>
         <SheetTrigger asChild>
-          <Button>Open {position} sheet</Button>
+          <Button>{t('example.sheet.position.openSheet', { position })}</Button>
         </SheetTrigger>
         <SheetContent side={position} size="content">
           <SheetHeader>
-            <SheetTitle>Edit profile</SheetTitle>
+            <SheetTitle>{t('example.sheet.position.title')}</SheetTitle>
             <SheetDescription>
-              Make changes to your profile here. Click save when you're done.
+              {t('example.sheet.position.description')}
             </SheetDescription>
           </SheetHeader>
           <div className="grid gap-4 py-4">
             <div className="grid grid-cols-4 items-center gap-4">
               <Label htmlFor="name" className="text-right">
-                Name
+                {t('example.sheet.position.name')}
               </Label>
               <Input id="name" value="Pedro Duarte" className="col-span-3" />
             </div>
             <div className="grid grid-cols-4 items-center gap-4">
               <Label htmlFor="username" className="text-right">
-                Username
+                {t('example.sheet.position.username')}
               </Label>
               <Input id="username" value="@peduarte" className="col-span-3" />
             </div>
           </div>
           <SheetFooter>
-            <Button type="submit">Save changes</Button>
+            <Button type="submit">{t('example.sheet.position.saveChanges')}</Button>
           </SheetFooter>
         </SheetContent>
       </Sheet>

--- a/src/pages/example/sheet/size.tsx
+++ b/src/pages/example/sheet/size.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -19,6 +20,7 @@ const SHEET_SIZES = ['sm', 'default', 'lg', 'xl', 'full', 'content'] as const;
 type SheetSize = (typeof SHEET_SIZES)[number]
 
 export default function SheetSize() {
+  const { t } = useTranslation();
   const [size, setSize] = useState<SheetSize>('default');
   return (
     <div className="flex flex-col space-y-8">
@@ -40,31 +42,31 @@ export default function SheetSize() {
       </RadioGroup>
       <Sheet>
         <SheetTrigger asChild>
-          <Button>Open {size} sheet</Button>
+          <Button>{t('example.sheet.size.openSheet', { size })}</Button>
         </SheetTrigger>
         <SheetContent side="right" size={size}>
           <SheetHeader>
-            <SheetTitle>Edit profile</SheetTitle>
+            <SheetTitle>{t('example.sheet.size.title')}</SheetTitle>
             <SheetDescription>
-              Make changes to your profile here. Click save when you're done.
+              {t('example.sheet.size.description')}
             </SheetDescription>
           </SheetHeader>
           <div className="grid gap-4 py-4">
             <div className="grid grid-cols-4 items-center gap-4">
               <Label htmlFor="name" className="text-right">
-                Name
+                {t('example.sheet.size.name')}
               </Label>
               <Input id="name" value="Pedro Duarte" className="col-span-3" />
             </div>
             <div className="grid grid-cols-4 items-center gap-4">
               <Label htmlFor="username" className="text-right">
-                Username
+                {t('example.sheet.size.username')}
               </Label>
               <Input id="username" value="@peduarte" className="col-span-3" />
             </div>
           </div>
           <SheetFooter>
-            <Button type="submit">Save changes</Button>
+            <Button type="submit">{t('example.sheet.size.saveChanges')}</Button>
           </SheetFooter>
         </SheetContent>
       </Sheet>

--- a/src/pages/example/switch/demo.tsx
+++ b/src/pages/example/switch/demo.tsx
@@ -1,11 +1,13 @@
+import { useTranslation } from 'react-i18next';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 
 export default function SwitchDemo() {
+  const { t } = useTranslation();
   return (
     <div className="flex items-center space-x-2">
       <Switch id="airplane-mode" />
-      <Label htmlFor="airplane-mode">Airplane Mode</Label>
+      <Label htmlFor="airplane-mode">{t('example.switch.label')}</Label>
     </div>
   );
 }

--- a/src/pages/example/tabs/demo.tsx
+++ b/src/pages/example/tabs/demo.tsx
@@ -12,57 +12,59 @@ import { Label } from '@/components/ui/label';
 import {
   Tabs, TabsContent, TabsList, TabsTrigger,
 } from '@/components/ui/tabs';
+import { useTranslation } from 'react-i18next';
 
 export default function TabsDemo() {
+  const { t } = useTranslation();
   return (
     <Tabs defaultValue="account" className="w-[400px]">
       <TabsList className="grid w-full grid-cols-2">
-        <TabsTrigger value="account">Account</TabsTrigger>
-        <TabsTrigger value="password">Password</TabsTrigger>
+        <TabsTrigger value="account">{t('example.tabs.account')}</TabsTrigger>
+        <TabsTrigger value="password">{t('example.tabs.password')}</TabsTrigger>
       </TabsList>
       <TabsContent value="account">
         <Card>
           <CardHeader>
-            <CardTitle>Account</CardTitle>
+            <CardTitle>{t('example.tabs.account')}</CardTitle>
             <CardDescription>
-              Make changes to your account here. Click save when you're done.
+              {t('example.tabs.accountDescription')}
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-2">
             <div className="space-y-1">
-              <Label htmlFor="name">Name</Label>
+              <Label htmlFor="name">{t('example.tabs.name')}</Label>
               <Input id="name" defaultValue="Pedro Duarte" />
             </div>
             <div className="space-y-1">
-              <Label htmlFor="username">Username</Label>
+              <Label htmlFor="username">{t('example.tabs.username')}</Label>
               <Input id="username" defaultValue="@peduarte" />
             </div>
           </CardContent>
           <CardFooter>
-            <Button>Save changes</Button>
+            <Button>{t('example.tabs.saveChanges')}</Button>
           </CardFooter>
         </Card>
       </TabsContent>
       <TabsContent value="password">
         <Card>
           <CardHeader>
-            <CardTitle>Password</CardTitle>
+            <CardTitle>{t('example.tabs.password')}</CardTitle>
             <CardDescription>
-              Change your password here. After saving, you'll be logged out.
+              {t('example.tabs.passwordDescription')}
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-2">
             <div className="space-y-1">
-              <Label htmlFor="current">Current password</Label>
+              <Label htmlFor="current">{t('example.tabs.currentPassword')}</Label>
               <Input id="current" type="password" />
             </div>
             <div className="space-y-1">
-              <Label htmlFor="new">New password</Label>
+              <Label htmlFor="new">{t('example.tabs.newPassword')}</Label>
               <Input id="new" type="password" />
             </div>
           </CardContent>
           <CardFooter>
-            <Button>Save password</Button>
+            <Button>{t('example.tabs.savePassword')}</Button>
           </CardFooter>
         </Card>
       </TabsContent>

--- a/src/pages/example/textarea/demo.tsx
+++ b/src/pages/example/textarea/demo.tsx
@@ -1,5 +1,7 @@
+import { useTranslation } from 'react-i18next';
 import { Textarea } from '@/components/ui/textarea';
 
 export default function TextareaDemo() {
-  return <Textarea placeholder="Type your message here." />;
+  const { t } = useTranslation();
+  return <Textarea placeholder={t('example.textarea.placeholder')} />;
 }

--- a/src/pages/example/textarea/disabled.tsx
+++ b/src/pages/example/textarea/disabled.tsx
@@ -1,5 +1,7 @@
+import { useTranslation } from 'react-i18next';
 import { Textarea } from '@/components/ui/textarea';
 
 export default function TextareaDisabled() {
-  return <Textarea placeholder="Type your message here." disabled />;
+  const { t } = useTranslation();
+  return <Textarea placeholder={t('example.textarea.disabled.placeholder')} disabled />;
 }

--- a/src/pages/example/textarea/with-button.tsx
+++ b/src/pages/example/textarea/with-button.tsx
@@ -1,11 +1,13 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 
 export default function TextareaWithButton() {
+  const { t } = useTranslation();
   return (
     <div className="grid w-full gap-2">
-      <Textarea placeholder="Type your message here." />
-      <Button>Send message</Button>
+      <Textarea placeholder={t('example.textarea.withButton.placeholder')} />
+      <Button>{t('example.textarea.withButton.button')}</Button>
     </div>
   );
 }

--- a/src/pages/example/textarea/with-label.tsx
+++ b/src/pages/example/textarea/with-label.tsx
@@ -1,11 +1,13 @@
+import { useTranslation } from 'react-i18next';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 
 export default function TextareaWithLabel() {
+  const { t } = useTranslation();
   return (
     <div className="grid w-full gap-1.5">
-      <Label htmlFor="message">Your message</Label>
-      <Textarea placeholder="Type your message here." id="message" />
+      <Label htmlFor="message">{t('example.textarea.withLabel.label')}</Label>
+      <Textarea placeholder={t('example.textarea.withLabel.placeholder')} id="message" />
     </div>
   );
 }

--- a/src/pages/example/textarea/with-text.tsx
+++ b/src/pages/example/textarea/with-text.tsx
@@ -1,13 +1,15 @@
+import { useTranslation } from 'react-i18next';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 
 export default function TextareaWithText() {
+  const { t } = useTranslation();
   return (
     <div className="grid w-full gap-1.5">
-      <Label htmlFor="message-2">Your Message</Label>
-      <Textarea placeholder="Type your message here." id="message-2" />
+      <Label htmlFor="message-2">{t('example.textarea.withText.label')}</Label>
+      <Textarea placeholder={t('example.textarea.withText.placeholder')} id="message-2" />
       <p className="text-sm text-muted-foreground">
-        Your message will be copied to the support team.
+        {t('example.textarea.withText.description')}
       </p>
     </div>
   );

--- a/src/pages/example/toast/demo.tsx
+++ b/src/pages/example/toast/demo.tsx
@@ -1,24 +1,26 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { ToastAction } from '@/components/ui/toast';
 import { useToast } from '@/components/ui/use-toast';
 
 export default function ToastDemo() {
   const { toast } = useToast();
+  const { t } = useTranslation();
 
   return (
     <Button
       variant="outline"
       onClick={() => {
         toast({
-          title: 'Scheduled: Catch up ',
-          description: 'Friday, February 10, 2023 at 5:57 PM',
+          title: t('example.toast.title'),
+          description: t('example.toast.description'),
           action: (
-            <ToastAction altText="Goto schedule to undo">Undo</ToastAction>
+            <ToastAction altText={t('example.toast.undoAltText')}>{t('example.toast.undo')}</ToastAction>
           ),
         });
       }}
     >
-      Add to calendar
+      {t('example.toast.button')}
     </Button>
   );
 }

--- a/src/pages/example/toast/destructive.tsx
+++ b/src/pages/example/toast/destructive.tsx
@@ -1,9 +1,11 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { ToastAction } from '@/components/ui/toast';
 import { useToast } from '@/components/ui/use-toast';
 
 export default function ToastDestructive() {
   const { toast } = useToast();
+  const { t } = useTranslation();
 
   return (
     <Button
@@ -11,13 +13,13 @@ export default function ToastDestructive() {
       onClick={() => {
         toast({
           variant: 'destructive',
-          title: 'Uh oh! Something went wrong.',
-          description: 'There was a problem with your request.',
-          action: <ToastAction altText="Try again">Try again</ToastAction>,
+          title: t('example.toast.destructive.title'),
+          description: t('example.toast.destructive.description'),
+          action: <ToastAction altText={t('example.toast.destructive.action')}>{t('example.toast.destructive.action')}</ToastAction>,
         });
       }}
     >
-      Show Toast
+      {t('example.toast.destructive.button')}
     </Button>
   );
 }

--- a/src/pages/example/toast/simple.tsx
+++ b/src/pages/example/toast/simple.tsx
@@ -1,19 +1,21 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 
 export default function ToastSimple() {
   const { toast } = useToast();
+  const { t } = useTranslation();
 
   return (
     <Button
       variant="outline"
       onClick={() => {
         toast({
-          description: 'Your message has been sent.',
+          description: t('example.toast.simple.description'),
         });
       }}
     >
-      Show Toast
+      {t('example.toast.simple.button')}
     </Button>
   );
 }

--- a/src/pages/example/toast/with-action.tsx
+++ b/src/pages/example/toast/with-action.tsx
@@ -1,22 +1,24 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { ToastAction } from '@/components/ui/toast';
 import { useToast } from '@/components/ui/use-toast';
 
 export default function ToastWithAction() {
   const { toast } = useToast();
+  const { t } = useTranslation();
 
   return (
     <Button
       variant="outline"
       onClick={() => {
         toast({
-          title: 'Uh oh! Something went wrong.',
-          description: 'There was a problem with your request.',
-          action: <ToastAction altText="Try again">Try again</ToastAction>,
+          title: t('example.toast.withAction.title'),
+          description: t('example.toast.withAction.description'),
+          action: <ToastAction altText={t('example.toast.withAction.action')}>{t('example.toast.withAction.action')}</ToastAction>,
         });
       }}
     >
-      Show Toast
+      {t('example.toast.withAction.button')}
     </Button>
   );
 }

--- a/src/pages/example/toast/with-title.tsx
+++ b/src/pages/example/toast/with-title.tsx
@@ -1,20 +1,22 @@
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 
 export default function ToastWithTitle() {
   const { toast } = useToast();
+  const { t } = useTranslation();
 
   return (
     <Button
       variant="outline"
       onClick={() => {
         toast({
-          title: 'Uh oh! Something went wrong.',
-          description: 'There was a problem with your request.',
+          title: t('example.toast.withTitle.title'),
+          description: t('example.toast.withTitle.description'),
         });
       }}
     >
-      Show Toast
+      {t('example.toast.withTitle.button')}
     </Button>
   );
 }

--- a/src/pages/example/toggle/demo.tsx
+++ b/src/pages/example/toggle/demo.tsx
@@ -1,9 +1,11 @@
 import { Bold } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Toggle } from '@/components/ui/toggle';
 
 export default function ToggleDemo() {
+  const { t } = useTranslation();
   return (
-    <Toggle aria-label="Toggle italic">
+    <Toggle aria-label={t('example.toggle.toggleItalic')}>
       <Bold className="h-4 w-4" />
     </Toggle>
   );

--- a/src/pages/example/toggle/disabled.tsx
+++ b/src/pages/example/toggle/disabled.tsx
@@ -1,9 +1,11 @@
 import { Underline } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Toggle } from '@/components/ui/toggle';
 
 export default function ToggleDisabled() {
+  const { t } = useTranslation();
   return (
-    <Toggle aria-label="Toggle italic" disabled>
+    <Toggle aria-label={t('example.toggle.disabled.toggleItalic')} disabled>
       <Underline className="h-4 w-4" />
     </Toggle>
   );

--- a/src/pages/example/toggle/lg.tsx
+++ b/src/pages/example/toggle/lg.tsx
@@ -1,9 +1,11 @@
 import { Italic } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Toggle } from '@/components/ui/toggle';
 
 export default function ToggleLg() {
+  const { t } = useTranslation();
   return (
-    <Toggle size="lg" aria-label="Toggle italic">
+    <Toggle size="lg" aria-label={t('example.toggle.lg.toggleItalic')}>
       <Italic className="h-4 w-4" />
     </Toggle>
   );

--- a/src/pages/example/toggle/outline.tsx
+++ b/src/pages/example/toggle/outline.tsx
@@ -1,9 +1,11 @@
 import { Italic } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Toggle } from '@/components/ui/toggle';
 
 export default function ToggleOutline() {
+  const { t } = useTranslation();
   return (
-    <Toggle variant="outline" aria-label="Toggle italic">
+    <Toggle variant="outline" aria-label={t('example.toggle.outline.toggleItalic')}>
       <Italic className="h-4 w-4" />
     </Toggle>
   );

--- a/src/pages/example/toggle/sm.tsx
+++ b/src/pages/example/toggle/sm.tsx
@@ -1,9 +1,11 @@
 import { Italic } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Toggle } from '@/components/ui/toggle';
 
 export default function ToggleSm() {
+  const { t } = useTranslation();
   return (
-    <Toggle size="sm" aria-label="Toggle italic">
+    <Toggle size="sm" aria-label={t('example.toggle.sm.toggleItalic')}>
       <Italic className="h-4 w-4" />
     </Toggle>
   );

--- a/src/pages/example/toggle/with-text.tsx
+++ b/src/pages/example/toggle/with-text.tsx
@@ -1,11 +1,13 @@
 import { Italic } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Toggle } from '@/components/ui/toggle';
 
 export default function ToggleWithText() {
+  const { t } = useTranslation();
   return (
-    <Toggle aria-label="Toggle italic">
+    <Toggle aria-label={t('example.toggle.withText.toggleItalic')}>
       <Italic className="mr-2 h-4 w-4" />
-      Italic
+      {t('example.toggle.withText.italic')}
     </Toggle>
   );
 }

--- a/src/pages/example/tooltip/demo.tsx
+++ b/src/pages/example/tooltip/demo.tsx
@@ -1,21 +1,23 @@
 import { Plus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,
 } from '@/components/ui/tooltip';
 
 export default function TooltipDemo() {
+  const { t } = useTranslation();
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
           <Button variant="outline" className="w-10 rounded-full p-0">
             <Plus className="h-4 w-4" />
-            <span className="sr-only">Add</span>
+            <span className="sr-only">{t('example.tooltip.add')}</span>
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p>Add to library</p>
+          <p>{t('example.tooltip.addToLibrary')}</p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/src/pages/example/typography/blockquote.tsx
+++ b/src/pages/example/typography/blockquote.tsx
@@ -1,8 +1,10 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographyBlockquote() {
+  const { t } = useTranslation();
   return (
     <blockquote className="mt-6 border-l-2 pl-6 italic">
-      "After all," he said, "everyone enjoys a good joke, so it's only fair that
-      they should pay for the privilege."
+      {t('example.typography.blockquote.quote')}
     </blockquote>
   );
 }

--- a/src/pages/example/typography/demo.tsx
+++ b/src/pages/example/typography/demo.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 import TypographyH1 from '@/pages/example/typography/h1';
 import TypographyH2 from '@/pages/example/typography/h2';
 import TypographyH3 from '@/pages/example/typography/h3';
@@ -5,141 +7,126 @@ import TypographyH4 from '@/pages/example/typography/h4';
 import TypographyInlineCode from '@/pages/example/typography/inline-code';
 
 export default function TypographyDemo() {
+  const { t } = useTranslation();
   return (
     <div>
       <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl">
-        The Joke Tax Chronicles
+        {t('example.typography.demo.title')}
       </h1>
       <p className="leading-7 [&:not(:first-child)]:mt-6">
-        Once upon a time, in a far-off land, there was a very lazy king who
-        spent all day lounging on his throne. One day, his advisors came to him
-        with a problem: the kingdom was running out of money.
+        {t('example.typography.demo.intro')}
       </p>
       <h2 className="mt-10 scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0">
-        The King's Plan
+        {t('example.typography.demo.kingsPlanHeading')}
       </h2>
       <p className="leading-7 [&:not(:first-child)]:mt-6">
-        The king thought long and hard, and finally came up with{' '}
+        {t('example.typography.demo.kingsPlanBefore')}{' '}
         <a
           href="#"
           className="font-medium text-primary underline underline-offset-4"
         >
-          a brilliant plan
+          {t('example.typography.demo.kingsPlanLink')}
         </a>
-        : he would tax the jokes in the kingdom.
+        {t('example.typography.demo.kingsPlanAfter')}
       </p>
       <blockquote className="mt-6 border-l-2 pl-6 italic">
-        &quot;After all,&quot; he said, &quot;everyone enjoys a good joke, so it&apos;s only fair
-        that they should pay for the privilege.&quot;
+        {t('example.typography.demo.quote')}
       </blockquote>
       <h3 className="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">
-        The Joke Tax
+        {t('example.typography.demo.jokeTaxHeading')}
       </h3>
       <p className="leading-7 [&:not(:first-child)]:mt-6">
-        The king&apos;s subjects were not amused. They grumbled and complained, but
-        the king was firm:
+        {t('example.typography.demo.jokeTaxParagraph')}
       </p>
       <ul className="my-6 ml-6 list-disc [&>li]:mt-2">
-        <li>1st level of puns: 5 gold coins</li>
-        <li>2nd level of jokes: 10 gold coins</li>
-        <li>3rd level of one-liners : 20 gold coins</li>
+        <li>{t('example.typography.demo.item1')}</li>
+        <li>{t('example.typography.demo.item2')}</li>
+        <li>{t('example.typography.demo.item3')}</li>
       </ul>
       <p className="leading-7 [&:not(:first-child)]:mt-6">
-        As a result, people stopped telling jokes, and the kingdom fell into a
-        gloom. But there was one person who refused to let the king&apos;s
-        foolishness get him down: a court jester named Jokester.
+        {t('example.typography.demo.jesterParagraph')}
       </p>
       <h3 className="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">
-        Jokester&apos;s Revolt
+        {t('example.typography.demo.revoltHeading')}
       </h3>
       <p className="leading-7 [&:not(:first-child)]:mt-6">
-        Jokester began sneaking into the castle in the middle of the night and
-        leaving jokes all over the place: under the king&apos;s pillow, in his soup,
-        even in the royal toilet. The king was furious, but he couldn&apos;t seem to
-        stop Jokester.
+        {t('example.typography.demo.revoltParagraph')}
       </p>
       <p className="leading-7 [&:not(:first-child)]:mt-6">
-        And then, one day, the people of the kingdom discovered that the jokes
-        left by Jokester were so funny that they couldn&apos;t help but laugh. And
-        once they started laughing, they couldn&apos;t stop.
+        {t('example.typography.demo.laughterParagraph')}
       </p>
       <h3 className="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">
-        The People&apos;s Rebellion
+        {t('example.typography.demo.rebellionHeading')}
       </h3>
       <p className="leading-7 [&:not(:first-child)]:mt-6">
-        The people of the kingdom, feeling uplifted by the laughter, started to
-        tell jokes and puns again, and soon the entire kingdom was in on the
-        joke.
+        {t('example.typography.demo.rebellionParagraph')}
       </p>
       <div className="my-6 w-full overflow-y-auto">
         <table className="w-full">
           <thead>
             <tr className="m-0 border-t p-0 even:bg-muted">
               <th className="border px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right">
-                King&apos;s Treasury
+                {t('example.typography.demo.colTreasury')}
               </th>
               <th className="border px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right">
-                People&apos;s happiness
+                {t('example.typography.demo.colHappiness')}
               </th>
             </tr>
           </thead>
           <tbody>
             <tr className="m-0 border-t p-0 even:bg-muted">
               <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-                Empty
+                {t('example.typography.demo.row1Treasury')}
               </td>
               <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-                Overflowing
-              </td>
-            </tr>
-            <tr className="m-0 border-t p-0 even:bg-muted">
-              <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-                Modest
-              </td>
-              <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-                Satisfied
+                {t('example.typography.demo.row1Happiness')}
               </td>
             </tr>
             <tr className="m-0 border-t p-0 even:bg-muted">
               <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-                Full
+                {t('example.typography.demo.row2Treasury')}
               </td>
               <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-                Ecstatic
+                {t('example.typography.demo.row2Happiness')}
+              </td>
+            </tr>
+            <tr className="m-0 border-t p-0 even:bg-muted">
+              <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
+                {t('example.typography.demo.row3Treasury')}
+              </td>
+              <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
+                {t('example.typography.demo.row3Happiness')}
               </td>
             </tr>
           </tbody>
         </table>
       </div>
       <p className="leading-7 [&:not(:first-child)]:mt-6">
-        The king, seeing how much happier his subjects were, realized the error
-        of his ways and repealed the joke tax. Jokester was declared a hero, and
-        the kingdom lived happily ever after.
+        {t('example.typography.demo.repealParagraph')}
       </p>
       <p className="leading-7 [&:not(:first-child)]:mt-6">
-        The moral of the story is: never underestimate the power of a good laugh
-        and always be careful of bad ideas.
+        {t('example.typography.demo.moralParagraph')}
       </p>
       <div>
-        <p>h1</p>
+        <p>{t('example.typography.demo.labelH1')}</p>
         <div className="py-2">
           <TypographyH1 />
         </div>
-        <p>h2</p>
+        <p>{t('example.typography.demo.labelH2')}</p>
         <div className="py-2">
           <TypographyH2 />
         </div>
-        <p>h3</p>
+        <p>{t('example.typography.demo.labelH3')}</p>
         <div className="py-2">
           <TypographyH3 />
         </div>
-        <p>h4</p>
+        <p>{t('example.typography.demo.labelH4')}</p>
         <div className="py-2">
           <TypographyH4 />
         </div>
       </div>
       <div>
-        <p>Inline Code</p>
+        <p>{t('example.typography.demo.labelInlineCode')}</p>
         <TypographyInlineCode />
       </div>
     </div>

--- a/src/pages/example/typography/h1.tsx
+++ b/src/pages/example/typography/h1.tsx
@@ -1,7 +1,10 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographyH1() {
+  const { t } = useTranslation();
   return (
     <h1 className="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl">
-      Taxing Laughter: The Joke Tax Chronicles
+      {t('example.typography.h1.heading')}
     </h1>
   );
 }

--- a/src/pages/example/typography/h2.tsx
+++ b/src/pages/example/typography/h2.tsx
@@ -1,7 +1,10 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographyH2() {
+  const { t } = useTranslation();
   return (
     <h2 className="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0">
-      The People of the Kingdom
+      {t('example.typography.h2.heading')}
     </h2>
   );
 }

--- a/src/pages/example/typography/h3.tsx
+++ b/src/pages/example/typography/h3.tsx
@@ -1,7 +1,10 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographyH3() {
+  const { t } = useTranslation();
   return (
     <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">
-      The Joke Tax
+      {t('example.typography.h3.heading')}
     </h3>
   );
 }

--- a/src/pages/example/typography/h4.tsx
+++ b/src/pages/example/typography/h4.tsx
@@ -1,7 +1,10 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographyH4() {
+  const { t } = useTranslation();
   return (
     <h4 className="scroll-m-20 text-xl font-semibold tracking-tight">
-      People stopped telling jokes
+      {t('example.typography.h4.heading')}
     </h4>
   );
 }

--- a/src/pages/example/typography/large.tsx
+++ b/src/pages/example/typography/large.tsx
@@ -1,5 +1,10 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographyLarge() {
+  const { t } = useTranslation();
   return (
-    <div className="text-lg font-semibold">Are you sure absolutely sure?</div>
+    <div className="text-lg font-semibold">
+      {t('example.typography.large.text')}
+    </div>
   );
 }

--- a/src/pages/example/typography/lead.tsx
+++ b/src/pages/example/typography/lead.tsx
@@ -1,8 +1,10 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographyLead() {
+  const { t } = useTranslation();
   return (
     <p className="text-xl text-muted-foreground">
-      A modal dialog that interrupts the user with important content and expects
-      a response.
+      {t('example.typography.lead.lead')}
     </p>
   );
 }

--- a/src/pages/example/typography/list.tsx
+++ b/src/pages/example/typography/list.tsx
@@ -1,9 +1,12 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographyList() {
+  const { t } = useTranslation();
   return (
     <ul className="my-6 ml-6 list-disc [&>li]:mt-2">
-      <li>1st level of puns: 5 gold coins</li>
-      <li>2nd level of jokes: 10 gold coins</li>
-      <li>3rd level of one-liners : 20 gold coins</li>
+      <li>{t('example.typography.list.item1')}</li>
+      <li>{t('example.typography.list.item2')}</li>
+      <li>{t('example.typography.list.item3')}</li>
     </ul>
   );
 }

--- a/src/pages/example/typography/muted.tsx
+++ b/src/pages/example/typography/muted.tsx
@@ -1,5 +1,10 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographyMuted() {
+  const { t } = useTranslation();
   return (
-    <p className="text-sm text-muted-foreground">Enter your email address.</p>
+    <p className="text-sm text-muted-foreground">
+      {t('example.typography.muted.text')}
+    </p>
   );
 }

--- a/src/pages/example/typography/p.tsx
+++ b/src/pages/example/typography/p.tsx
@@ -1,8 +1,10 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographyP() {
+  const { t } = useTranslation();
   return (
     <p className="leading-7 [&:not(:first-child)]:mt-6">
-      The king, seeing how much happier his subjects were, realized the error of
-      his ways and repealed the joke tax.
+      {t('example.typography.p.paragraph')}
     </p>
   );
 }

--- a/src/pages/example/typography/small.tsx
+++ b/src/pages/example/typography/small.tsx
@@ -1,5 +1,10 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographySmall() {
+  const { t } = useTranslation();
   return (
-    <small className="text-sm font-medium leading-none">Email address</small>
+    <small className="text-sm font-medium leading-none">
+      {t('example.typography.small.text')}
+    </small>
   );
 }

--- a/src/pages/example/typography/table.tsx
+++ b/src/pages/example/typography/table.tsx
@@ -1,40 +1,43 @@
+import { useTranslation } from 'react-i18next';
+
 export default function TypographyTable() {
+  const { t } = useTranslation();
   return (
     <div className="my-6 w-full overflow-y-auto">
       <table className="w-full">
         <thead>
           <tr className="m-0 border-t p-0 even:bg-muted">
             <th className="border px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right">
-              King's Treasury
+              {t('example.typography.table.colTreasury')}
             </th>
             <th className="border px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right">
-              People's happiness
+              {t('example.typography.table.colHappiness')}
             </th>
           </tr>
         </thead>
         <tbody>
           <tr className="m-0 border-t p-0 even:bg-muted">
             <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-              Empty
+              {t('example.typography.table.row1Treasury')}
             </td>
             <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-              Overflowing
-            </td>
-          </tr>
-          <tr className="m-0 border-t p-0 even:bg-muted">
-            <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-              Modest
-            </td>
-            <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-              Satisfied
+              {t('example.typography.table.row1Happiness')}
             </td>
           </tr>
           <tr className="m-0 border-t p-0 even:bg-muted">
             <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-              Full
+              {t('example.typography.table.row2Treasury')}
             </td>
             <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
-              Ecstatic
+              {t('example.typography.table.row2Happiness')}
+            </td>
+          </tr>
+          <tr className="m-0 border-t p-0 even:bg-muted">
+            <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
+              {t('example.typography.table.row3Treasury')}
+            </td>
+            <td className="border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right">
+              {t('example.typography.table.row3Happiness')}
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
## 개요 / Summary

기존에는 example 페이지 73개 중 6개만 i18n이 적용되어 있었고 나머지는 영어 하드코딩이었습니다. 이 PR로 **모든 example/demo 페이지를 react-i18next로 연결하고 한국어·영어 번역을 전부 추가**했습니다.

## 변경 내용

- **로케일**: `public/locales/en.yml` · `ko.yml`에 `example.*` 하위로 **288개 키 추가** (폼 / 오버레이 / 메뉴 / command 팔레트 / 토스트 / 타이포그래피 / 디스플레이 컴포넌트). en↔ko **키 완전 일치**(각 327개 문자열).
- **코드 연결**: 약 **60개 example `.tsx`** 파일에 `useTranslation`/`t()` 적용.
- **하드코딩 유지(의도적)**: 인명(Pedro Duarte 등), `@핸들`, 브랜드명(shadcn/ui, Radix UI), 이메일, lorem ipsum, 키보드 단축키(⌘ 등), 숫자/ID 값 — 더미 데이터는 번역 대상이 아니므로 그대로 둠.
- **동적 보간**: sheet의 `position`/`size` 라벨은 i18next interpolation(`Open {{position}} sheet`) 사용.
- **버그 수정**: 소문자 컴포넌트명(`function index`)을 `DropdownMenuDemo`로 변경 → 추가된 훅이 `rules-of-hooks` 통과.

## 작업 방식

분량이 커서(67개 파일) 6개 병렬 에이전트로 분담했고, 각 에이전트는 담당 파일만 수정하고 번역은 fragment JSON으로 출력 → 충돌 없이 로케일에 일괄 병합했습니다.

## 검증

| Check | Result |
|---|---|
| 코드의 `t()` 키 320개 → en/ko 정의 | ✅ 미정의 0 |
| en/ko 키 parity | ✅ 일치 (327/327) |
| `pnpm tsc` | ✅ 0 errors |
| `pnpm lint` | ✅ 0 errors |
| `pnpm test` | ✅ 7 passed |
| `pnpm build` | ✅ |
| dev 예제 라우트 렌더 | ✅ HTTP 200 (dropdown/menubar/typography/sheet/toast 등) |

> 자동 번역 특성상 일부 한국어 표현은 취향에 따라 다듬을 수 있습니다. 특정 용어 통일이 필요하면 알려주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oJ9xs9iSZN3ahQ6hKsh3u

---
_Generated by [Claude Code](https://claude.ai/code/session_017oJ9xs9iSZN3ahQ6hKsh3u)_